### PR TITLE
Implementar perfils d'usuari i edicio de perfil. Refs #16

### DIFF
--- a/docs/CIMSCAT_FRONTEND_PERFILS.md
+++ b/docs/CIMSCAT_FRONTEND_PERFILS.md
@@ -1,0 +1,383 @@
+# CimsCat Frontend: Perfils
+
+## Objectiu d'aquest resum
+
+Documentar la implementacio feta al frontend per cobrir la part de perfils del projecte, especialment:
+
+- `ProfileView.vue`
+- `ForeignProfileView.vue`
+- carrusels horitzontals
+- modal d'edicio de perfil
+
+Aquest resum explica:
+
+- quina interpretacio funcional s'ha seguit
+- quines parts s'han connectat de veritat amb backend
+- quines parts s'han deixat preparades per al futur
+- quins fitxers s'han creat o modificat
+
+---
+
+## Context funcional del perfil
+
+Per aquesta part del projecte s'ha seguit una combinacio de tres fonts:
+
+1. el wireframe del perfil
+2. el document de conceptes del projecte
+3. la nomenclatura oficial definida a `docs`
+
+La interpretacio final acordada ha estat aquesta:
+
+- `Ultimes publicacions` = publicacions propies de l'usuari
+- `Publicacions guardades` = visualment aquest nom al perfil, pero tecnicament alimentades per `likes`
+- `Cims guardats` = cims oficials guardats per l'usuari
+- `Rutes planificades` = encara no implementat, es deixa com a placeholder
+- `Awards` = encara no implementat, es deixa com a placeholder visual
+
+Per al perfil alie:
+
+- nomes es mostra informacio publica
+- no es mostren cims guardats
+- no es mostren likes/guardats personals
+- no hi ha boto d'edicio
+
+---
+
+## Nomenclatura aplicada
+
+S'ha respectat la nomenclatura oficial del projecte:
+
+- `likes` nomes per publicacions
+- `saved` nomes per cims
+
+Per tant:
+
+- la seccio visible `Publicacions guardades` del perfil propi es connecta a `GET /users/:id/likes`
+- la seccio `Cims guardats` es connecta a `GET /users/:id/saved`
+
+Aquest punt era important per no barrejar:
+
+- publicacions d'altres usuaris amb like
+- cims oficials guardats
+
+---
+
+## Fitxers modificats o creats
+
+- `frontend/src/views/ProfileView.vue`
+- `frontend/src/views/ForeignProfileView.vue`
+- `frontend/src/components/HorizontalCarousel.vue`
+- `frontend/src/components/ProfilePublicationCard.vue`
+- `frontend/src/components/ProfilePeakCard.vue`
+- `frontend/src/components/EditProfileModal.vue`
+- `frontend/src/router/index.js`
+
+---
+
+## 1. Implementacio de `ProfileView.vue`
+
+Fitxer:
+
+- `frontend/src/views/ProfileView.vue`
+
+Objectiu:
+
+- representar el perfil propi de l'usuari autenticat
+- mostrar les seves dades personals i les seves seccions principals
+
+Contingut actual de la vista:
+
+- foto/avatar
+- nom de l'usuari
+- `Ultimes publicacions`
+- `Publicacions guardades`
+- `Cims guardats`
+- `Rutes planificades` placeholder
+- `Awards` placeholder
+- boto `Editar perfil`
+- modal d'edicio
+
+Logica important:
+
+- la ruta es considera de perfil propi
+- si l'`id` de la URL no coincideix amb l'usuari autenticat, la vista redirigeix al perfil alie
+- la carrega de dades es fa en paral·lel per aprofitar millor el temps:
+  - `GET /users/:id`
+  - `GET /users/:id/publications`
+  - `GET /users/:id/likes`
+  - `GET /users/:id/saved`
+
+Resultat:
+
+- el perfil propi queda connectat amb dades reals del backend
+- no es barregen dominis
+- el layout segueix el wireframe adaptat al projecte real
+
+---
+
+## 2. Implementacio de `ForeignProfileView.vue`
+
+Fitxer:
+
+- `frontend/src/views/ForeignProfileView.vue`
+
+Objectiu:
+
+- mostrar el perfil public d'un altre usuari
+
+Contingut actual:
+
+- avatar/foto
+- nom
+- `Ultimes publicacions`
+- bloc placeholder d'`Awards`
+
+Important:
+
+- no es mostren cims guardats
+- no es mostren likes personals
+- no hi ha boto `Editar perfil`
+- no hi ha modal
+
+Connexio real:
+
+- `GET /users/:id`
+- `GET /users/:id/publications`
+
+Resultat:
+
+- es diferencia clarament el perfil propi del perfil alie
+- es respecta la idea de privacitat del projecte
+
+---
+
+## 3. Carrusels horitzontals
+
+Fitxer:
+
+- `frontend/src/components/HorizontalCarousel.vue`
+
+Per que s'ha creat:
+
+- el projecte no tenia cap component reutilitzable per mostrar files horitzontals amb desplacament
+- el wireframe del perfil demanava seccions amb navegacio lateral
+
+Que fa:
+
+- mostra un titol de seccio
+- opcionalment una descripcio
+- mostra els elements en una fila horitzontal
+- te boto esquerra i boto dreta
+- si no hi ha dades, mostra un missatge buit
+
+Avantatge:
+
+- el mateix component es pot reutilitzar per:
+  - publicacions
+  - likes/publicacions guardades
+  - cims guardats
+  - altres seccions futures
+
+---
+
+## 4. Targeta de publicacio del perfil
+
+Fitxer:
+
+- `frontend/src/components/ProfilePublicationCard.vue`
+
+Objectiu:
+
+- tenir una targeta simple per a:
+  - ultimes publicacions
+  - publicacions guardades
+
+Contingut:
+
+- imatge
+- titol
+- autor
+- boto/enllac a la publicacio
+
+Detall important:
+
+- si la publicacio no te imatge propia, es prova d'agafar la imatge del cim associat
+- si tampoc n'hi ha, es mostra una imatge fallback
+
+---
+
+## 5. Targeta de cim guardat
+
+Fitxer:
+
+- `frontend/src/components/ProfilePeakCard.vue`
+
+Objectiu:
+
+- representar els cims guardats del perfil propi sense confondre'ls amb publicacions
+
+Contingut:
+
+- imatge del cim
+- nom
+- alcada
+- comarca
+- enllac a la fitxa oficial del cim
+
+Aixo reforca la diferenciacio entre:
+
+- contingut creat per usuaris
+- fitxes oficials de cims
+
+---
+
+## 6. Modal d'edicio de perfil
+
+Fitxer:
+
+- `frontend/src/components/EditProfileModal.vue`
+
+Objectiu:
+
+- permetre l'edicio del perfil propi des de la mateixa vista
+
+Camps actuals:
+
+- nom
+- cognom
+- nom d'usuari
+- foto de perfil
+
+Validacions aplicades:
+
+- nom obligatori
+- cognom obligatori
+- validacio basica de `nomUsuari`
+
+Connexio real:
+
+- `PUT /users/:id`
+
+Comportament:
+
+- s'obre des de `ProfileView`
+- si l'actualitzacio va be, es refresquen les dades locals del perfil
+- tambe s'actualitza la store de l'usuari autenticat
+
+---
+
+## 7. Rutes de perfil
+
+Fitxer:
+
+- `frontend/src/router/index.js`
+
+Canvi aplicat:
+
+- `/perfil/:id` es reserva per al perfil propi
+- `/usuari/:id` es fa servir per al perfil alie
+
+Per que es fa aixi:
+
+- evita barreges entre les dues vistes
+- fa mes clara la navegacio
+- permet redirigir correctament quan una URL de perfil propi en realitat apunta a un usuari diferent
+
+---
+
+## 8. Accessos des de publicacions
+
+Fitxer relacionat:
+
+- `frontend/src/views/PublicationView.vue`
+
+Canvi relacionat amb perfils:
+
+- el nom i la foto de l'autor ja enllacen al perfil corresponent
+- si l'autor es l'usuari autenticat:
+  - va a `/perfil/:id`
+- si es un altre usuari:
+  - va a `/usuari/:id`
+
+Aixo evita haver d'escriure URLs manuals per veure un perfil alie.
+
+---
+
+## 9. Què està connectat de veritat
+
+- `GET /users/:id`
+- `GET /users/:id/publications`
+- `GET /users/:id/likes`
+- `GET /users/:id/saved`
+- `PUT /users/:id`
+
+Per tant, la part principal del perfil propi ja treballa amb dades reals:
+
+- dades de perfil
+- publicacions propies
+- publicacions guardades visualment via likes
+- cims guardats
+- edicio del perfil
+
+I el perfil alie tambe te connexio real en la part publica:
+
+- dades basiques del perfil
+- publicacions publiques
+
+---
+
+## 10. Què queda pendent o com a placeholder
+
+Encara no s'ha implementat amb dades reals:
+
+- `Rutes planificades`
+- `Awards`
+- estadistiques de km
+- grafiques
+- insígnies
+- reptes
+- seguir usuaris
+
+Per decisio de tasca, aquestes parts s'han deixat:
+
+- visibles com a estructura
+- pero sense inventar backend ni dades falses innecessaries
+
+---
+
+## 11. Resultat funcional
+
+Amb aquesta implementacio:
+
+- el perfil propi ja te estructura real i util
+- el perfil alie ja existeix com a vista separada
+- la navegacio entre publicacions i perfils ja queda connectada
+- la UI segueix la logica del wireframe adaptada al projecte real
+- les parts futures no bloquegen la feina actual perquè queden preparades visualment
+
+---
+
+## 12. Limitacions conegudes
+
+- `Awards` no te backend ni dades reals encara
+- `Rutes planificades` no te integracio d'usuari encara
+- la foto de perfil depen de la ruta real retornada pel backend i dels fitxers disponibles a `uploads`
+- si algun endpoint d'usuari falla en local, el perfil no podra carregar aquella seccio concreta
+
+---
+
+## Resum curt final
+
+La part de perfils del frontend queda implementada amb:
+
+- perfil propi real
+- perfil alie real
+- carrusels horitzontals
+- edicio de perfil
+- separacio correcta entre publicacions, likes i cims guardats
+
+I es deixa preparat per ampliar mes endavant:
+
+- awards
+- estadistiques
+- rutes planificades

--- a/frontend/src/components/EditProfileModal.vue
+++ b/frontend/src/components/EditProfileModal.vue
@@ -1,0 +1,306 @@
+<template>
+  <!--
+    Fem el modal com una capa per sobre de la pàgina.
+    És només per al perfil propi i serveix per editar els camps bàsics que el backend permet.
+    Aquí la idea és:
+    - obrir una finestra per sobre del perfil
+    - deixar editar quatre camps senzills
+    - validar una mica abans d'enviar
+  -->
+  <!--
+    @click.self fa que el modal es tanqui si cliquem al fons fosc,
+    però no si cliquem dins de la targeta blanca.
+  -->
+  <div class="edit-profile-modal" @click.self="$emit('close')">
+    <article class="edit-profile-modal__card">
+      <!-- Capçalera del modal -->
+      <div class="edit-profile-modal__header">
+        <div>
+          <p class="edit-profile-modal__eyebrow">Perfil</p>
+          <h2 class="edit-profile-modal__title">Editar perfil</h2>
+        </div>
+
+        <button class="edit-profile-modal__close" type="button" @click="$emit('close')">
+          ✕
+        </button>
+      </div>
+
+      <!-- Formulari del modal -->
+      <form class="edit-profile-modal__form" @submit.prevent="handleSubmit">
+        <label class="edit-profile-modal__field">
+          <span>Nom</span>
+          <input v-model="localForm.nom" type="text" />
+        </label>
+
+        <label class="edit-profile-modal__field">
+          <span>Cognom</span>
+          <input v-model="localForm.cognom" type="text" />
+        </label>
+
+        <label class="edit-profile-modal__field">
+          <span>Nom d'usuari</span>
+          <input v-model="localForm.nomUsuari" type="text" />
+        </label>
+
+        <label class="edit-profile-modal__field">
+          <span>Foto de perfil</span>
+          <input type="file" accept="image/*" @change="handleImageSelection" />
+          <small class="edit-profile-modal__hint">
+            Pots triar una imatge del teu ordinador o escriure una ruta/manualment si ja tens una URL.
+          </small>
+        </label>
+
+        <label class="edit-profile-modal__field">
+          <span>Foto de perfil (URL o path)</span>
+          <input v-model="localForm.fotoPerfil" type="text" placeholder="/uploads/usuaris/..." />
+        </label>
+
+        <div v-if="localForm.fotoPerfil" class="edit-profile-modal__preview">
+          <img :src="localForm.fotoPerfil" alt="Previsualitzacio de la foto de perfil" />
+        </div>
+
+        <!-- Si tenim errors de validació, els ensenyem aquí -->
+        <div v-if="errors.length" class="edit-profile-modal__errors">
+          <ul>
+            <li v-for="error in errors" :key="error">{{ error }}</li>
+          </ul>
+        </div>
+
+        <!-- Botons finals d'acció -->
+        <div class="edit-profile-modal__actions">
+          <button type="button" class="edit-profile-modal__secondary" @click="$emit('close')">
+            Cancel·lar
+          </button>
+          <button type="submit" class="edit-profile-modal__primary" :disabled="loading">
+            {{ loading ? 'Guardant...' : 'Guardar canvis' }}
+          </button>
+        </div>
+      </form>
+    </article>
+  </div>
+</template>
+
+<script setup>
+// ref guarda l'estat local del formulari i watch ens ajuda a sincronitzar-lo amb el pare.
+import { ref, watch } from 'vue'
+
+// Rebrem des del perfil el formulari inicial i si l'acció de guardar està carregant.
+const props = defineProps({
+  initialForm: {
+    type: Object,
+    required: true,
+  },
+  loading: {
+    type: Boolean,
+    default: false,
+  },
+})
+
+const emit = defineEmits(['close', 'submit'])
+
+// Aquest és el formulari local del modal.
+// És local perquè no volem modificar directament el perfil original mentre l'usuari escriu.
+const localForm = ref({
+  nom: '',
+  cognom: '',
+  nomUsuari: '',
+  fotoPerfil: '',
+})
+
+const errors = ref([])
+
+watch(
+  () => props.initialForm,
+  (value) => {
+    // Cada vegada que s'obre el modal o canvien les dades d'entrada,
+    // copiem aquestes dades al formulari local.
+    localForm.value = {
+      nom: value.nom || '',
+      cognom: value.cognom || '',
+      nomUsuari: value.nomUsuari || '',
+      fotoPerfil: value.fotoPerfil || '',
+    }
+    errors.value = []
+  },
+  { immediate: true, deep: true },
+)
+
+function handleSubmit() {
+  // Aquí fem una validació bàsica abans d'enviar res al perfil.
+  const nextErrors = []
+
+  if (!localForm.value.nom.trim()) nextErrors.push('El nom és obligatori.')
+  if (!localForm.value.cognom.trim()) nextErrors.push('El cognom és obligatori.')
+  if (!/^[a-z0-9._]{3,30}$/.test(localForm.value.nomUsuari.trim().toLowerCase())) {
+    nextErrors.push("El nom d'usuari ha de tenir 3-30 caràcters amb minúscules, números, . o _.")
+  }
+
+  errors.value = nextErrors
+  if (nextErrors.length) return
+
+  // Si tot és correcte, enviem cap al component pare només les dades netes.
+  emit('submit', {
+    nom: localForm.value.nom.trim(),
+    cognom: localForm.value.cognom.trim(),
+    nomUsuari: localForm.value.nomUsuari.trim().toLowerCase(),
+    fotoPerfil: localForm.value.fotoPerfil.trim() || null,
+  })
+}
+
+function handleImageSelection(event) {
+  // Aquí agafem el fitxer del selector del navegador.
+  // Com que backend no té encara un endpoint específic d'uploads d'usuari,
+  // el convertim a data URL per poder-lo desar dins del camp fotoPerfil.
+  const [file] = event.target.files || []
+  if (!file) return
+
+  const reader = new FileReader()
+
+  reader.onload = () => {
+    if (typeof reader.result === 'string') {
+      localForm.value.fotoPerfil = reader.result
+    }
+  }
+
+  reader.readAsDataURL(file)
+}
+</script>
+
+<style scoped>
+/* Fons fosc que tapa tota la pantalla */
+.edit-profile-modal {
+  position: fixed;
+  inset: 0;
+  background: rgba(31, 34, 27, 0.45);
+  display: grid;
+  place-items: center;
+  padding: 1rem;
+  z-index: 50;
+}
+
+/* Targeta blanca central del modal */
+.edit-profile-modal__card {
+  width: min(100%, 620px);
+  background: var(--color-surface);
+  border-radius: 18px;
+  border: 1px solid var(--color-border);
+  padding: 1.5rem;
+}
+
+/* Capçalera amb títol i botó de tancar */
+.edit-profile-modal__header {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  align-items: flex-start;
+}
+
+/* Text petit superior */
+.edit-profile-modal__eyebrow {
+  margin: 0 0 0.35rem;
+  color: #8a9581;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.82rem;
+}
+
+.edit-profile-modal__title {
+  margin: 0;
+  font-size: 2rem;
+  color: var(--color-text);
+}
+
+/* Botó petit de tancar */
+.edit-profile-modal__close {
+  border: 1px solid var(--color-border);
+  background: #fff;
+  border-radius: 10px;
+  width: 42px;
+  height: 42px;
+  cursor: pointer;
+}
+
+/* Graella vertical del formulari */
+.edit-profile-modal__form {
+  margin-top: 1.25rem;
+  display: grid;
+  gap: 1rem;
+}
+
+/* Cada camp té etiqueta + input */
+.edit-profile-modal__field {
+  display: grid;
+  gap: 0.4rem;
+  color: var(--color-text);
+  font-weight: 600;
+}
+
+/* Aparença dels inputs */
+.edit-profile-modal__field input {
+  border: 1px solid var(--color-border);
+  border-radius: 12px;
+  padding: 0.8rem 0.95rem;
+  font: inherit;
+}
+
+.edit-profile-modal__hint {
+  color: var(--color-text-soft);
+  font-weight: 400;
+}
+
+.edit-profile-modal__preview {
+  display: flex;
+  justify-content: flex-start;
+}
+
+.edit-profile-modal__preview img {
+  width: 112px;
+  height: 112px;
+  object-fit: cover;
+  border-radius: 50%;
+  border: 1px solid var(--color-border);
+  background: #f2f1ec;
+}
+
+/* Caixa d'errors */
+.edit-profile-modal__errors {
+  border: 1px solid #e2caca;
+  background: #fff7f7;
+  color: #9a4d4d;
+  border-radius: 12px;
+  padding: 0.9rem 1rem;
+}
+
+.edit-profile-modal__errors ul {
+  margin: 0;
+  padding-left: 1.1rem;
+}
+
+/* Zona de botons finals */
+.edit-profile-modal__actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.8rem;
+}
+
+.edit-profile-modal__secondary,
+.edit-profile-modal__primary {
+  border-radius: 10px;
+  padding: 0.8rem 1rem;
+  cursor: pointer;
+  font: inherit;
+}
+
+/* Botó secundari de cancel·lar */
+.edit-profile-modal__secondary {
+  border: 1px solid var(--color-border);
+  background: #fff;
+}
+
+/* Botó principal de guardar */
+.edit-profile-modal__primary {
+  border: none;
+  background: var(--color-button-primary);
+  color: var(--color-button-primary-text);
+}
+</style>

--- a/frontend/src/components/HorizontalCarousel.vue
+++ b/frontend/src/components/HorizontalCarousel.vue
@@ -1,0 +1,196 @@
+<template>
+  <!--
+    Aquest component ens serveix per reutilitzar el mateix patró de carrusel
+    a diferents seccions del perfil. La idea és simple: una fila horitzontal
+    amb scroll i dos botons per desplaçar-nos cap a l'esquerra o la dreta.
+    El component no sap quin contingut hi ha dins:
+    això li arriba des del pare mitjançant slots.
+  -->
+  <section class="horizontal-carousel">
+    <!-- Capçalera de la secció -->
+    <div class="horizontal-carousel__header">
+      <h2 class="horizontal-carousel__title">{{ title }}</h2>
+      <slot name="header-extra" />
+    </div>
+
+    <!-- Descripció opcional per afegir context a la secció -->
+    <div v-if="description" class="horizontal-carousel__description">
+      {{ description }}
+    </div>
+
+    <!-- Si hi ha items, mostrem el carrusel real -->
+    <div v-if="items.length" class="horizontal-carousel__body">
+      <button
+        class="horizontal-carousel__arrow"
+        type="button"
+        aria-label="Desplaçar a l'esquerra"
+        @click="scrollByAmount(-1)"
+      >
+        ←
+      </button>
+
+      <!--
+        Aquesta és la pista horitzontal que es desplaça.
+        A dins hi renderitzem un slot per cada element rebut.
+      -->
+      <div ref="trackRef" class="horizontal-carousel__track">
+        <slot
+          v-for="(item, index) in items"
+          :key="getItemKey(item, index)"
+          name="item"
+          :item="item"
+          :index="index"
+        />
+      </div>
+
+      <button
+        class="horizontal-carousel__arrow"
+        type="button"
+        aria-label="Desplaçar a la dreta"
+        @click="scrollByAmount(1)"
+      >
+        →
+      </button>
+    </div>
+
+    <!-- Si no hi ha dades, mostrem l'estat buit -->
+    <div v-else class="horizontal-carousel__empty">
+      {{ emptyText }}
+    </div>
+  </section>
+</template>
+
+<script setup>
+// Aquest component només gestiona la part visual i el desplaçament horitzontal.
+// El contingut concret de cada targeta ens el passa el pare amb slots.
+import { ref } from 'vue'
+
+// Definim les propietats perquè aquest carrusel sigui reutilitzable a diferents seccions.
+const props = defineProps({
+  title: {
+    type: String,
+    required: true,
+  },
+  items: {
+    type: Array,
+    default: () => [],
+  },
+  emptyText: {
+    type: String,
+    default: 'No hi ha elements per mostrar en aquesta secció.',
+  },
+  description: {
+    type: String,
+    default: '',
+  },
+})
+
+// Referència al contenidor que es desplaça.
+const trackRef = ref(null)
+
+function scrollByAmount(direction) {
+  // Fem un scroll aproximat a l'amplada d'una targeta gran per mantenir
+  // un comportament simple i fàcil d'entendre.
+  if (!trackRef.value) return
+
+  trackRef.value.scrollBy({
+    left: direction * 320,
+    behavior: 'smooth',
+  })
+}
+
+function getItemKey(item, index) {
+  // Si l'element ja té id, l'aprofitem; si no, fem servir l'índex.
+  // Això evita warnings de Vue quan fem v-for.
+  return item?.id || item?.peak?.id || item?.publication?.id || index
+}
+</script>
+
+<style scoped>
+/* El component s'organitza en vertical: títol, descripció i contingut */
+.horizontal-carousel {
+  display: flex;
+  flex-direction: column;
+  gap: 0.9rem;
+}
+
+/* Capçalera de la secció */
+.horizontal-carousel__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+}
+
+.horizontal-carousel__title {
+  margin: 0;
+  font-size: 1.85rem;
+  color: var(--color-text);
+}
+
+/* Text opcional explicatiu */
+.horizontal-carousel__description {
+  color: var(--color-text-soft);
+  line-height: 1.6;
+  font-size: 0.95rem;
+}
+
+/* Cos del carrusel: fletxa esquerra, pista central, fletxa dreta */
+.horizontal-carousel__body {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  gap: 0.85rem;
+  align-items: center;
+}
+
+/* La pista interior real que es desplaça horitzontalment */
+.horizontal-carousel__track {
+  display: flex;
+  gap: 1rem;
+  overflow-x: auto;
+  scroll-behavior: smooth;
+  padding-bottom: 0.35rem;
+  scrollbar-width: thin;
+}
+
+.horizontal-carousel__track::-webkit-scrollbar {
+  height: 8px;
+}
+
+.horizontal-carousel__track::-webkit-scrollbar-thumb {
+  background: #d7d8cf;
+  border-radius: 999px;
+}
+
+/* Botons rodons de navegació lateral */
+.horizontal-carousel__arrow {
+  width: 44px;
+  height: 44px;
+  border-radius: 999px;
+  border: 1px solid var(--color-border);
+  background: #fff;
+  color: var(--color-text);
+  cursor: pointer;
+  font-size: 1.35rem;
+}
+
+/* Estat buit quan no hi ha dades */
+.horizontal-carousel__empty {
+  padding: 1.15rem 1.25rem;
+  border: 1px dashed #d9ddd0;
+  border-radius: 14px;
+  background: #fbfbf7;
+  color: var(--color-text-soft);
+}
+
+@media (max-width: 720px) {
+  /* En pantalles petites traiem les fletxes i deixem només l'scroll tàctil */
+  .horizontal-carousel__body {
+    grid-template-columns: 1fr;
+  }
+
+  .horizontal-carousel__arrow {
+    display: none;
+  }
+}
+</style>

--- a/frontend/src/components/ProfilePeakCard.vue
+++ b/frontend/src/components/ProfilePeakCard.vue
@@ -1,0 +1,98 @@
+<template>
+  <!--
+    Aquesta targeta és per als cims guardats del perfil.
+    Aquí no parlem de publicacions d'usuari, sinó de fitxes oficials de cim.
+    Aquest detall és important perquè aquesta secció representa el concepte `saved`
+    del projecte, no pas `likes`.
+  -->
+  <article class="profile-peak-card">
+    <!-- Imatge principal del cim -->
+    <img :src="peakImage" :alt="peak.nom" class="profile-peak-card__image" />
+
+    <!-- Informació bàsica del cim -->
+    <div class="profile-peak-card__content">
+      <h3 class="profile-peak-card__title">{{ peak.nom }}</h3>
+      <p class="profile-peak-card__meta">{{ peak.alcada }} m</p>
+      <p class="profile-peak-card__meta">{{ peak.comarca }}</p>
+      <RouterLink :to="`/cim/${peak.id}`" class="profile-peak-card__link">
+        Veure pàgina del cim
+      </RouterLink>
+    </div>
+  </article>
+</template>
+
+<script setup>
+// computed ens ajuda a preparar la imatge final del cim.
+import { computed } from 'vue'
+import { resolveMediaUrl } from '../utils/media'
+
+// Esperem rebre un objecte cim ja preparat per pintar.
+const props = defineProps({
+  peak: {
+    type: Object,
+    required: true,
+  },
+})
+
+const peakImage = computed(
+  () =>
+    // Si el cim té imatge pròpia, la resolem.
+    // Si no, fem servir una imatge fallback per no deixar la targeta buida.
+    resolveMediaUrl(props.peak.imatgeUrl) ||
+    'https://images.unsplash.com/photo-1500530855697-b586d89ba3ee?auto=format&fit=crop&w=900&q=80',
+)
+</script>
+
+<style scoped>
+/* Targeta base del cim guardat */
+.profile-peak-card {
+  width: 260px;
+  min-width: 260px;
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: 14px;
+  overflow: hidden;
+}
+
+/* Imatge superior del cim */
+.profile-peak-card__image {
+  width: 100%;
+  height: 155px;
+  object-fit: cover;
+  display: block;
+}
+
+/* Informació textual de la targeta */
+.profile-peak-card__content {
+  padding: 0.95rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.profile-peak-card__title {
+  margin: 0;
+  font-size: 1.2rem;
+  line-height: 1.2;
+  color: var(--color-text);
+}
+
+/* Text secundari per alcada i comarca */
+.profile-peak-card__meta {
+  margin: 0;
+  color: var(--color-text-soft);
+  font-size: 0.92rem;
+}
+
+/* Enllaç a la fitxa oficial del cim */
+.profile-peak-card__link {
+  width: fit-content;
+  text-decoration: none;
+  color: var(--color-text);
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  padding: 0.45rem 0.8rem;
+  background: #fff;
+  margin-top: 0.35rem;
+}
+</style>

--- a/frontend/src/components/ProfilePublicationCard.vue
+++ b/frontend/src/components/ProfilePublicationCard.vue
@@ -1,0 +1,118 @@
+<template>
+  <!--
+    Aquesta targeta la fem per a publicacions dins del perfil.
+    Ens interessa una peça molt simple: imatge, títol, autor i un enllaç a la publicació.
+    La reutilitzem tant a:
+    - Últimes publicacions
+    - Publicacions guardades
+  -->
+  <article class="profile-publication-card">
+    <!-- Imatge principal de la publicació -->
+    <img
+      :src="coverImage"
+      :alt="publication.titol"
+      class="profile-publication-card__image"
+    />
+
+    <!-- Text i acció de la targeta -->
+    <div class="profile-publication-card__content">
+      <h3 class="profile-publication-card__title">{{ publication.titol }}</h3>
+      <p class="profile-publication-card__author">by {{ authorName }}</p>
+      <RouterLink :to="`/publicacio/${publication.id}`" class="profile-publication-card__link">
+        Veure publicació
+      </RouterLink>
+    </div>
+  </article>
+</template>
+
+<script setup>
+// computed ens va bé perquè coverImage i authorName depenen de la publicació rebuda.
+import { computed } from 'vue'
+import { resolveMediaUrl } from '../utils/media'
+
+// Aquesta targeta espera rebre una publicació completa o prou completa per pintar-se.
+const props = defineProps({
+  publication: {
+    type: Object,
+    required: true,
+  },
+})
+
+const coverImage = computed(
+  () =>
+    // Intentem diverses fonts d'imatge:
+    // 1) portada pròpia de la publicació
+    // 2) imatge del cim associat
+    // 3) fallback extern si no hi ha res més
+    resolveMediaUrl(
+      props.publication.portadaUrl ||
+        props.publication.cim?.imatgeUrl ||
+        props.publication.peak?.imatgeUrl,
+    ) ||
+    'https://images.unsplash.com/photo-1464822759023-fed622ff2c3b?auto=format&fit=crop&w=900&q=80',
+)
+
+const authorName = computed(() => {
+  // Igual que en altres pantalles, provem primer nom d'usuari.
+  // Si no hi és, intentem altres camps de l'autor.
+  return (
+    props.publication.author?.nomUsuari ||
+    props.publication.author?.nom ||
+    props.publication.nomUsuari ||
+    'Usuari'
+  )
+})
+</script>
+
+<style scoped>
+/* Targeta base de la publicació */
+.profile-publication-card {
+  width: 260px;
+  min-width: 260px;
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: 14px;
+  overflow: hidden;
+}
+
+/* Imatge superior */
+.profile-publication-card__image {
+  width: 100%;
+  height: 155px;
+  object-fit: cover;
+  display: block;
+}
+
+/* Bloc intern amb text i botó */
+.profile-publication-card__content {
+  padding: 0.95rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+}
+
+.profile-publication-card__title {
+  margin: 0;
+  font-size: 1.2rem;
+  line-height: 1.2;
+  color: var(--color-text);
+}
+
+/* Autor en format més secundari */
+.profile-publication-card__author {
+  margin: 0;
+  color: var(--color-text-soft);
+  font-size: 0.92rem;
+}
+
+/* Enllaç a la pàgina de la publicació */
+.profile-publication-card__link {
+  width: fit-content;
+  text-decoration: none;
+  color: var(--color-text);
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  padding: 0.45rem 0.8rem;
+  background: #fff;
+}
+</style>

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -56,7 +56,17 @@ const routes = [
     component: () => import('../views/PlanRouteView.vue'),
     meta: { requiresAuth: true },
   },
-  { path: '/perfil/:id', name: 'Perfil', component: () => import('../views/ProfileView.vue') },
+  {
+    path: '/perfil/:id',
+    name: 'Perfil',
+    component: () => import('../views/ProfileView.vue'),
+    meta: { requiresAuth: true },
+  },
+  {
+    path: '/usuari/:id',
+    name: 'PerfilAlie',
+    component: () => import('../views/ForeignProfileView.vue'),
+  },
   { path: '/cerca', name: 'Cerca', component: () => import('../views/SearchView.vue') },
   {
     path: '/admin',

--- a/frontend/src/views/ForeignProfileView.vue
+++ b/frontend/src/views/ForeignProfileView.vue
@@ -1,0 +1,231 @@
+<template>
+  <!--
+    Aquesta vista és per a perfils aliens.
+    Aquí és molt important no barrejar el perfil propi amb el perfil d'una altra persona.
+    Per això aquesta pàgina només mostra:
+    - nom
+    - avatar
+    - últimes publicacions públiques
+    I deixem fora qualsevol secció personal o privada.
+  -->
+  <section class="foreign-profile-view">
+    <!-- Estat simple de càrrega mentre arriben les dades -->
+    <div v-if="isLoading" class="foreign-profile-state">
+      Carregant perfil públic...
+    </div>
+
+    <!-- Estat d'error si backend no respon o l'usuari no existeix -->
+    <div v-else-if="errorMessage" class="foreign-profile-state foreign-profile-state--error">
+      {{ errorMessage }}
+    </div>
+
+    <!-- Contingut principal quan ja tenim dades -->
+    <article v-else-if="profile" class="foreign-profile-card">
+      <header class="foreign-profile-header">
+        <!-- Mateixa idea visual que al perfil propi: contingut a l'esquerra, foto a la dreta -->
+        <div class="foreign-profile-header__main">
+          <div class="foreign-profile-header__identity">
+            <h1 class="foreign-profile-header__title">{{ fullName }}</h1>
+          </div>
+
+          <!--
+            En perfil aliè mantenim només la secció pública de publicacions.
+            No mostrem likes personals, ni cims guardats, ni editar perfil.
+          -->
+          <HorizontalCarousel
+            title="Últimes publicacions"
+            :items="publications"
+            empty-text="Aquest usuari encara no té publicacions visibles."
+          >
+            <template #item="{ item }">
+              <ProfilePublicationCard :publication="item" />
+            </template>
+          </HorizontalCarousel>
+        </div>
+
+        <img :src="profileImage" :alt="fullName" class="foreign-profile-header__avatar" />
+      </header>
+
+      <!-- Placeholder simple d'awards per mantenir el buit funcional reservat -->
+      <section class="foreign-profile-section foreign-profile-section--placeholder">
+        <h2 class="foreign-profile-section__title">Awards</h2>
+        <p class="foreign-profile-section__text">
+          Aquesta part quedarà disponible més endavant quan es defineixi i s’implementi la part
+          d’estadístiques i insígnies.
+        </p>
+      </section>
+    </article>
+  </section>
+</template>
+
+<script setup>
+// Aquí fem servir el mateix patró reactiu del perfil propi, però simplificat.
+import { computed, ref, watch } from 'vue'
+import { useRoute } from 'vue-router'
+import api from '../api/axios'
+import HorizontalCarousel from '../components/HorizontalCarousel.vue'
+import ProfilePublicationCard from '../components/ProfilePublicationCard.vue'
+import { resolveMediaUrl } from '../utils/media'
+
+const route = useRoute()
+
+// Estat principal de la vista
+const profile = ref(null)
+const publications = ref([])
+const isLoading = ref(true)
+const errorMessage = ref('')
+
+// Imatge de suport si l'usuari no té avatar o la ruta falla
+const fallbackAvatar =
+  'https://images.unsplash.com/photo-1535713875002-d1d0cf377fde?auto=format&fit=crop&w=240&q=80'
+
+const fullName = computed(() => {
+  // Muntem el nom visible de la mateixa manera que al perfil propi.
+  if (!profile.value) return ''
+  return [profile.value.nom, profile.value.cognom].filter(Boolean).join(' ') || profile.value.nomUsuari
+})
+
+const profileImage = computed(
+  () => resolveMediaUrl(profile.value?.fotoPerfil) || fallbackAvatar,
+)
+
+function getApiErrorMessage(error, fallbackMessage) {
+  // Intentem aprofitar el text que hagi donat backend abans d'ensenyar un missatge genèric.
+  return (
+    error?.response?.data?.message ||
+    error?.response?.data?.error?.message ||
+    fallbackMessage
+  )
+}
+
+async function fetchForeignProfile() {
+  // Aquesta funció carrega el perfil públic i les seves publicacions.
+  // No demanem likes ni saved perquè aquestes parts són privades del perfil propi.
+  isLoading.value = true
+  errorMessage.value = ''
+
+  try {
+    const userId = String(route.params.id)
+
+    // Fem les dues peticions en paral·lel perquè la càrrega sigui més àgil.
+    const [profileResponse, publicationsResponse] = await Promise.all([
+      api.get(`/users/${userId}`),
+      api.get(`/users/${userId}/publications`),
+    ])
+
+    // Guardem el resultat a l'estat reactiu.
+    profile.value = profileResponse.data.user
+    publications.value = publicationsResponse.data.publications || []
+  } catch (error) {
+    // Si alguna cosa falla, netegem les dades i mostrem error.
+    profile.value = null
+    publications.value = []
+    errorMessage.value = getApiErrorMessage(error, 'No hem pogut carregar aquest perfil públic.')
+  } finally {
+    isLoading.value = false
+  }
+}
+
+watch(
+  () => route.params.id,
+  () => {
+    // Tornem a carregar cada vegada que canvia l'id de la URL.
+    fetchForeignProfile()
+  },
+  { immediate: true },
+)
+</script>
+
+<style scoped>
+/* Contenidor general de la pàgina */
+.foreign-profile-view {
+  max-width: 1120px;
+  margin: 0 auto;
+  padding: 2rem 1rem 3rem;
+}
+
+/* Aparença bàsica dels estats i de la targeta principal */
+.foreign-profile-state,
+.foreign-profile-card {
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: 18px;
+  padding: 1.5rem;
+}
+
+.foreign-profile-state--error {
+  border-color: #e2caca;
+  background: #fff7f7;
+  color: #9a4d4d;
+}
+
+/* Header amb dues columnes: contingut i avatar */
+.foreign-profile-header {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 320px;
+  align-items: start;
+  gap: 2rem;
+}
+
+/* Columna esquerra del header */
+.foreign-profile-header__main {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.foreign-profile-header__title {
+  margin: 0;
+  font-size: clamp(2rem, 5vw, 3.2rem);
+  line-height: 1.02;
+  color: var(--color-text);
+}
+
+/* Avatar del perfil aliè */
+.foreign-profile-header__avatar {
+  width: 220px;
+  height: 220px;
+  border-radius: 50%;
+  object-fit: cover;
+  border: 1px solid var(--color-border);
+  background: #f2f1ec;
+}
+
+/* Separació vertical entre les diferents seccions de la pàgina */
+.foreign-profile-card {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+/* Caixa provisional per a awards futurs */
+.foreign-profile-section--placeholder {
+  padding: 1.25rem 1.35rem;
+  border-radius: 16px;
+  background: #f4f1e6;
+  border: 1px dashed #d8d2bc;
+}
+
+.foreign-profile-section__title {
+  margin: 0 0 0.5rem;
+  font-size: 1.55rem;
+}
+
+.foreign-profile-section__text {
+  margin: 0;
+  color: var(--color-text-soft);
+  line-height: 1.7;
+}
+
+@media (max-width: 760px) {
+  /* En mòbil eliminem la doble columna i ho apilem */
+  .foreign-profile-header {
+    grid-template-columns: 1fr;
+  }
+
+  .foreign-profile-header__avatar {
+    width: 160px;
+    height: 160px;
+  }
+}
+</style>

--- a/frontend/src/views/ProfileView.vue
+++ b/frontend/src/views/ProfileView.vue
@@ -1,7 +1,449 @@
 <template>
   <!--
-    Aquesta vista encara és placeholder.
-    La deixem visible per recordar que el perfil és una pantalla pendent de construir.
+    Aquesta és la vista del perfil propi.
+    La idea d'aquesta pàgina és:
+    1) carregar les dades del mateix usuari autenticat
+    2) mostrar-les en un format semblant al wireframe
+    3) separar bé cada tipus de contingut:
+       - publicacions pròpies
+       - publicacions amb like (visualment "guardades")
+       - cims guardats
+    4) deixar preparades seccions futures com Awards i Rutes planificades
   -->
-  <div>Perfil</div>
+  <section class="profile-view">
+    <!-- Si encara estem esperant la resposta del backend, mostrem aquest estat simple -->
+    <div v-if="isLoading" class="profile-state">
+      Carregant perfil...
+    </div>
+
+    <!-- Si alguna crida falla, ensenyem un missatge d'error en comptes de deixar la pàgina buida -->
+    <div v-else-if="errorMessage" class="profile-state profile-state--error">
+      {{ errorMessage }}
+    </div>
+
+    <!-- Quan ja tenim dades del perfil, renderitzem el contingut real -->
+    <article v-else-if="profile" class="profile-card">
+      <header class="profile-header">
+        <!--
+          Aquest bloc esquerre és la "part editorial" del perfil:
+          nom gran + primera secció de contingut.
+          Ho fem així perquè visualment s'assembla més al wireframe.
+        -->
+        <div class="profile-header__main">
+          <div class="profile-header__identity">
+            <h1 class="profile-header__title">{{ fullName }}</h1>
+          </div>
+
+          <!--
+            Primera fila important del perfil:
+            últimes publicacions pròpies de l'usuari.
+            Reutilitzem el component de carousel perquè després el puguem fer servir
+            també a altres seccions.
+          -->
+          <HorizontalCarousel
+            title="Últimes publicacions"
+            :items="ownPublications"
+            empty-text="Encara no has publicat cap sortida."
+          >
+            <template #item="{ item }">
+              <ProfilePublicationCard :publication="item" />
+            </template>
+          </HorizontalCarousel>
+        </div>
+
+        <!--
+          Aquesta columna dreta representa la part de "identitat":
+          foto de perfil + acció principal d'editar.
+        -->
+        <div class="profile-header__aside">
+          <img :src="profileImage" :alt="fullName" class="profile-header__avatar" />
+
+          <button class="profile-header__edit" type="button" @click="isEditModalOpen = true">
+            Editar perfil
+          </button>
+        </div>
+      </header>
+
+      <!--
+        Aquesta secció visualment diu "Publicacions guardades",
+        però tècnicament ve de l'endpoint de likes.
+        Ho fem així perquè el text és més natural per l'usuari final.
+      -->
+      <HorizontalCarousel
+        title="Publicacions guardades"
+        description="Aquesta secció mostra les publicacions a les quals has donat like."
+        :items="likedPublications"
+        empty-text="Encara no has donat like a cap publicació."
+      >
+        <template #item="{ item }">
+          <ProfilePublicationCard :publication="item" />
+        </template>
+      </HorizontalCarousel>
+
+      <!-- Aquí sí parlem de cims oficials guardats, no de publicacions -->
+      <HorizontalCarousel
+        title="Cims guardats"
+        :items="savedPeaks"
+        empty-text="Encara no tens cap cim guardat."
+      >
+        <template #item="{ item }">
+          <ProfilePeakCard :peak="item" />
+        </template>
+      </HorizontalCarousel>
+
+      <!-- Placeholder conscient: aquesta part encara no té backend ni lògica real d'usuari -->
+      <section class="profile-section profile-section--placeholder">
+        <h2 class="profile-section__title">Rutes planificades</h2>
+        <p class="profile-section__text">
+          Aquesta part quedarà disponible quan s’implementi la funcionalitat de planificar rutes i
+          la seva relació amb el perfil de l’usuari.
+        </p>
+      </section>
+
+      <!-- Placeholder visual per a les estadístiques i insígnies futures -->
+      <section class="profile-section profile-section--placeholder">
+        <h2 class="profile-section__title">Awards</h2>
+        <p class="profile-section__text">
+          Aquest bloc queda reservat per a estadístiques, insígnies i reptes. De moment només el
+          deixem preparat visualment per al futur.
+        </p>
+
+        <div class="profile-awards-grid">
+          <article class="profile-award-stat">0 km aquest any</article>
+          <article class="profile-award-stat">0 km aquest mes</article>
+          <article class="profile-award-stat">0 km aquesta setmana</article>
+          <div class="profile-award-box">Gràfica de progrés pendent</div>
+          <div class="profile-award-box">Reptes i llistats pendents</div>
+          <div class="profile-award-box">Insígnies pendents</div>
+        </div>
+      </section>
+    </article>
+
+    <!--
+      El modal només apareix quan l'usuari clica "Editar perfil".
+      Li passem:
+      - el formulari inicial
+      - l'estat de loading del guardat
+      - els esdeveniments de tancar i enviar
+    -->
+    <EditProfileModal
+      v-if="isEditModalOpen"
+      :initial-form="editForm"
+      :loading="isSavingProfile"
+      @close="isEditModalOpen = false"
+      @submit="handleProfileUpdate"
+    />
+  </section>
 </template>
+
+<script setup>
+// computed ens serveix per derivar valors sense haver-los de recalcular a mà tota l'estona.
+// ref ens permet guardar l'estat reactiu d'aquesta vista.
+// watch ens ajuda a reaccionar quan canvia la URL.
+import { computed, ref, watch } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import api from '../api/axios'
+import HorizontalCarousel from '../components/HorizontalCarousel.vue'
+import ProfilePublicationCard from '../components/ProfilePublicationCard.vue'
+import ProfilePeakCard from '../components/ProfilePeakCard.vue'
+import EditProfileModal from '../components/EditProfileModal.vue'
+import { useUserStore } from '../stores/user'
+import { resolveMediaUrl } from '../utils/media'
+
+const route = useRoute()
+const router = useRouter()
+const userStore = useUserStore()
+
+// Aquí guardem les diferents peces de dades que volem mostrar al perfil.
+const profile = ref(null)
+const ownPublications = ref([])
+const likedPublications = ref([])
+const savedPeaks = ref([])
+const isLoading = ref(true)
+const errorMessage = ref('')
+const isEditModalOpen = ref(false)
+const isSavingProfile = ref(false)
+
+// Si el backend no retorna cap foto o la foto falla, fem servir aquesta imatge de suport.
+const fallbackAvatar =
+  'https://images.unsplash.com/photo-1535713875002-d1d0cf377fde?auto=format&fit=crop&w=240&q=80'
+
+const fullName = computed(() => {
+  // Aquí intentem construir el nom gran del perfil de la manera més amigable possible.
+  // Si tenim nom i cognom, els unim.
+  // Si no, mostrem el nom d'usuari.
+  if (!profile.value) return ''
+  return [profile.value.nom, profile.value.cognom].filter(Boolean).join(' ') || profile.value.nomUsuari
+})
+
+const profileImage = computed(() => resolveMediaUrl(profile.value?.fotoPerfil) || fallbackAvatar)
+
+const editForm = computed(() => ({
+  // Aquesta computed prepara l'objecte base que rebrà el modal.
+  // Ho fem així perquè el modal sempre rebi dades actualitzades del perfil.
+  nom: profile.value?.nom || '',
+  cognom: profile.value?.cognom || '',
+  nomUsuari: profile.value?.nomUsuari || '',
+  fotoPerfil: profile.value?.fotoPerfil || '',
+}))
+
+function getApiErrorMessage(error, fallbackMessage) {
+  // Intentem recuperar el missatge més concret que ens hagi tornat el backend.
+  // Si no hi ha cap text útil, fem servir el missatge genèric que ens arriba per paràmetre.
+  return (
+    error?.response?.data?.message ||
+    error?.response?.data?.error?.message ||
+    fallbackMessage
+  )
+}
+
+function normalizeSavedPeaks(items) {
+  // El backend ens retorna cada element guardat embolicat dins d'un objecte "saved".
+  // Aquí el que fem és aplanar la forma perquè la targeta del cim ho tingui més fàcil.
+  return (items || []).map((item) => ({
+    ...item.peak,
+    savedAt: item.savedAt,
+  }))
+}
+
+function normalizeLikedPublications(items) {
+  // Amb els likes passa una cosa semblant:
+  // backend retorna un objecte de like que conté la publicació.
+  // Aquí convertim cada element en una publicació "normal" per reutilitzar la targeta.
+  return (items || []).map((item) => ({
+    ...item.publication,
+    likedAt: item.likedAt,
+  }))
+}
+
+async function fetchOwnProfile() {
+  // Aquesta ruta queda reservada al perfil propi.
+  // Si l'id de la URL no és el de l'usuari loguejat, el redirigim al perfil aliè.
+  const currentUserId = userStore.user?.id
+  const targetUserId = String(route.params.id)
+
+  if (!currentUserId) {
+    router.push('/login')
+    return
+  }
+
+  if (targetUserId !== currentUserId) {
+    router.replace(`/usuari/${targetUserId}`)
+    return
+  }
+
+  isLoading.value = true
+  errorMessage.value = ''
+
+  try {
+    // Fem totes les peticions en paral·lel perquè la pàgina carregui més ràpid.
+    const [profileResponse, publicationsResponse, likesResponse, savedResponse] = await Promise.all([
+      api.get(`/users/${currentUserId}`),
+      api.get(`/users/${currentUserId}/publications`),
+      api.get(`/users/${currentUserId}/likes`),
+      api.get(`/users/${currentUserId}/saved`),
+    ])
+
+    // Guardem cada bloc de dades a l'estat reactiu corresponent.
+    profile.value = profileResponse.data.user
+    ownPublications.value = publicationsResponse.data.publications || []
+    likedPublications.value = normalizeLikedPublications(likesResponse.data.likes)
+    savedPeaks.value = normalizeSavedPeaks(savedResponse.data.saved)
+  } catch (error) {
+    // Si alguna crida falla, netegem la vista perquè no quedin dades a mig estat.
+    profile.value = null
+    ownPublications.value = []
+    likedPublications.value = []
+    savedPeaks.value = []
+    errorMessage.value = getApiErrorMessage(error, 'No hem pogut carregar el teu perfil.')
+  } finally {
+    isLoading.value = false
+  }
+}
+
+async function handleProfileUpdate(payload) {
+  // Aquesta funció s'executa quan el modal ens envia el formulari ja validat.
+  isSavingProfile.value = true
+
+  try {
+    const currentUserId = userStore.user?.id
+    const { data } = await api.put(`/users/${currentUserId}`, payload)
+
+    // Actualitzem el perfil de la vista amb la resposta nova.
+    profile.value = data.user
+
+    // També actualitzem la store global perquè el navbar i la resta de l'app
+    // reflecteixin el nom o la foto nous sense haver de recarregar la pàgina.
+    userStore.setUser(
+      {
+        ...userStore.user,
+        ...data.user,
+      },
+      userStore.token,
+    )
+
+    isEditModalOpen.value = false
+  } catch (error) {
+    window.alert(getApiErrorMessage(error, 'No hem pogut actualitzar el perfil.'))
+  } finally {
+    isSavingProfile.value = false
+  }
+}
+
+watch(
+  () => route.params.id,
+  () => {
+    // Cada vegada que la URL del perfil canvia, tornem a carregar el perfil.
+    // Amb immediate: true també fem la primera càrrega quan la vista es munta.
+    fetchOwnProfile()
+  },
+  { immediate: true },
+)
+</script>
+
+<style scoped>
+/* Amplada màxima i espai lateral de la pàgina sencera del perfil */
+.profile-view {
+  max-width: 1160px;
+  margin: 0 auto;
+  padding: 2rem 1rem 3rem;
+}
+
+/* Estil bàsic compartit per als estats de loading/error i la targeta principal */
+.profile-state,
+.profile-card {
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: 18px;
+  padding: 1.5rem;
+}
+
+.profile-state--error {
+  background: #fff7f7;
+  border-color: #e2caca;
+  color: #9a4d4d;
+}
+
+/* El contingut intern del perfil s'apila verticalment per seccions */
+.profile-card {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+/* Header principal del perfil: contingut a l'esquerra i identitat a la dreta */
+.profile-header {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 320px;
+  gap: 2rem;
+  align-items: start;
+}
+
+/* Columna principal del header: nom + primera secció */
+.profile-header__main {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.profile-header__title {
+  margin: 0;
+  font-size: clamp(2.2rem, 5vw, 3.4rem);
+  line-height: 1.02;
+  color: var(--color-text);
+}
+
+/* Columna dreta: foto i boto d'editar */
+.profile-header__aside {
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 1rem;
+}
+
+.profile-header__avatar {
+  width: 220px;
+  height: 220px;
+  border-radius: 50%;
+  object-fit: cover;
+  border: 1px solid var(--color-border);
+  justify-self: center;
+  align-self: center;
+  background: #f2f1ec;
+}
+
+/* Boto d'editar perfil */
+.profile-header__edit {
+  border: none;
+  border-radius: 12px;
+  background: #efe9f7;
+  color: var(--color-text);
+  padding: 0.9rem 1rem;
+  cursor: pointer;
+  font: inherit;
+}
+
+/* Caixes placeholder per a funcionalitats futures */
+.profile-section--placeholder {
+  padding: 1.25rem 1.35rem;
+  border-radius: 16px;
+  background: #f4f1e6;
+  border: 1px dashed #d8d2bc;
+}
+
+.profile-section__title {
+  margin: 0 0 0.65rem;
+  font-size: 1.65rem;
+  color: var(--color-text);
+}
+
+.profile-section__text {
+  margin: 0;
+  color: var(--color-text-soft);
+  line-height: 1.7;
+}
+
+/* Graella d'awards provisional mentre no hi hagi dades reals */
+.profile-awards-grid {
+  margin-top: 1rem;
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1rem;
+}
+
+.profile-award-stat,
+.profile-award-box {
+  border-radius: 14px;
+  border: 1px solid #ddd8c6;
+  background: #fffaf1;
+  padding: 1rem;
+  color: var(--color-text-soft);
+}
+
+.profile-award-box {
+  min-height: 120px;
+  display: grid;
+  place-items: center;
+  text-align: center;
+}
+
+@media (max-width: 900px) {
+  /* En pantalles petites passem a una sola columna perquè el layout respiri millor */
+  .profile-header {
+    grid-template-columns: 1fr;
+  }
+
+  .profile-header__aside {
+    align-items: flex-start;
+  }
+
+  .profile-header__avatar {
+    width: 170px;
+    height: 170px;
+  }
+
+  .profile-awards-grid {
+    grid-template-columns: 1fr;
+  }
+}
+</style>

--- a/frontend/src/views/PublicationView.vue
+++ b/frontend/src/views/PublicationView.vue
@@ -29,14 +29,14 @@
             <p class="publication-eyebrow">Pàgina de publicació</p>
             <h1 class="publication-title">{{ publication.titol }}</h1>
 
-            <div class="publication-author">
+            <RouterLink :to="authorProfileLink" class="publication-author">
               <span class="publication-author__label">by {{ authorName }}</span>
               <img
                 :src="authorImage"
                 :alt="publication.author.nomUsuari || publication.author.nom || 'Autor'"
                 class="publication-author__avatar"
               />
-            </div>
+            </RouterLink>
           </div>
 
           <div class="publication-header__actions">
@@ -278,6 +278,14 @@ const authorName = computed(() => {
 const authorImage = computed(
   () => resolveMediaUrl(publication.value?.author?.fotoPerfil) || fallbackAvatar,
 )
+
+const authorProfileLink = computed(() => {
+  const authorId = publication.value?.author?.id
+
+  if (!authorId) return '/login'
+
+  return userStore.user?.id === authorId ? `/perfil/${authorId}` : `/usuari/${authorId}`
+})
 
 function getApiErrorMessage(error) {
   return (


### PR DESCRIPTION
S'ha implementat la part de frontend de perfils: ProfileView i ForeignProfileView, amb carrusels horitzontals, seccions separades per publicacions, likes i cims guardats, modal d'edició de perfil i navegació cap al perfil aliè des de les publicacions. Les parts d'Awards i Rutes planificades queden preparades com a placeholders visuals. Refs #16.