### PR TITLE
Polir detalls finals del frontend

### DIFF
--- a/docs/CIMSCAT_INTEGRACIO_POST_MERGE_BACKEND_FRONTEND.md
+++ b/docs/CIMSCAT_INTEGRACIO_POST_MERGE_BACKEND_FRONTEND.md
@@ -1,0 +1,386 @@
+# CIMSCAT INTEGRACIO POST-MERGE BACKEND + FRONTEND
+
+## Objectiu
+
+Documentar la integracio feta despres del merge del backend per deixar el projecte coherent entre frontend i backend.
+
+Aquest document recull:
+
+- resolucio del post-merge entre la branca local i `origin/main`
+- incorporacio del modul admin al backend
+- connexio del frontend amb els endpoints nous de saved peaks
+- connexio de l upload real de foto de perfil
+- implementacio real de la vista `/cerca`
+- connexio del logout frontend amb backend
+- correccio del bug `isAdmin` a l update de publicacions
+- inclusio de la migracio pendent de `RutaPlanificada.tipusRecorregut`
+
+No inclou actualitzacio general de documentacio antiga del projecte.
+
+## Context funcional
+
+Abans d aquesta integracio, el backend havia avançat amb noves funcionalitats:
+
+- endpoints per guardar i treure cims
+- endpoint d upload de foto de perfil a `/uploads/users`
+- filtres ampliats a `/peaks`
+- permisos admin en part de publicacions
+- endpoints admin per moderacio
+
+El frontend, pero, encara mantenia algunes parts visuals o locals:
+
+- el boto de guardar cim a la Home nomes canviava estat local
+- la foto de perfil es convertia a `data:` dins el modal
+- `/cerca` era una vista provisional
+- logout nomes netejava localStorage
+
+L objectiu de la integracio ha estat enganxar aquestes peces sense canviar el disseny general del projecte ni fer refactors grans.
+
+## Fitxers creats o modificats
+
+### Creats
+
+- `backend/src/modules/admin/admin.controller.js`
+- `backend/src/modules/admin/admin.routes.js`
+- `backend/src/modules/admin/admin.service.js`
+- `backend/src/modules/admin/admin.validators.js`
+- `backend/migrations/20260517174530_admin_endpoints_sync/migration.sql`
+
+### Modificats backend
+
+- `backend/src/app.js`
+- `backend/src/modules/peaks/peaks.routes.js`
+- `backend/src/modules/peaks/peaks.controller.js`
+- `backend/src/modules/peaks/peaks.service.js`
+- `backend/src/modules/publicacions/publicacions.controller.js`
+- `backend/prisma/seed.js`
+
+### Modificats frontend
+
+- `frontend/src/components/PeakCard.vue`
+- `frontend/src/components/EditProfileModal.vue`
+- `frontend/src/components/NavBar.vue`
+- `frontend/src/views/SearchView.vue`
+- `frontend/src/views/ProfileView.vue`
+- `frontend/src/views/CreatePublicationView.vue`
+- `frontend/src/views/AdminDashboard.vue`
+- `frontend/src/views/PeakDetailView.vue`
+- `frontend/src/views/PlanRouteView.vue`
+- `frontend/src/views/PublicationView.vue`
+- `frontend/src/views/RegisterView.vue`
+
+## 1. Estat post-merge
+
+La branca de treball usada ha estat:
+
+- `front_ajust`
+
+Es va integrar el contingut nou de `origin/main`, que incloia el backend del company.
+
+Durant el `stash pop` van aparèixer conflictes en:
+
+- `backend/src/modules/peaks/peaks.controller.js`
+- `backend/src/modules/peaks/peaks.service.js`
+
+Els conflictes es van resoldre mantenint:
+
+- la funcionalitat nova de saved peaks
+- la funcionalitat admin de delete peaks
+- exports/imports coherents entre controller i service
+
+Despres de la resolucio no quedaven marcadors de conflicte (`<<<<<<<`, `=======`, `>>>>>>>`).
+
+## 2. Modul admin backend
+
+El backend ja muntava admin des de `backend/src/app.js`:
+
+```js
+const adminRoutes = require('./modules/admin/admin.routes');
+app.use('/admin', adminRoutes);
+```
+
+Per tant, calia incloure la carpeta admin dins Git.
+
+Endpoints admin disponibles:
+
+- `GET /admin/comments`
+- `GET /admin/publicacions`
+- `GET /admin/users`
+- `GET /admin/search`
+- `PATCH /admin/users/:id`
+- `DELETE /admin/publicacions/:id`
+- `DELETE /admin/users/:id`
+
+Tots aquests endpoints fan servir:
+
+- `requireAuth`
+- `requireAdmin`
+
+El frontend `AdminDashboard.vue` ja consumeix aquests endpoints.
+
+## 3. Saved peaks connectat al frontend
+
+Fitxer principal:
+
+- `frontend/src/components/PeakCard.vue`
+
+Abans:
+
+- el boto de guardar cim nomes canviava `isSaved` localment
+- el comptador `savedCount` pujava o baixava visualment
+- no es guardava res a base de dades
+
+Ara:
+
+- en carregar la card, si l usuari esta autenticat, es consulta:
+  - `GET /peaks/:id/saved`
+- quan l usuari guarda:
+  - `POST /peaks/:id/saved`
+- quan l usuari treu de guardats:
+  - `DELETE /peaks/:id/saved`
+
+Resultat:
+
+- el guardat de cims persisteix a backend
+- el perfil pot mostrar els cims guardats reals amb `GET /users/:id/saved`
+- el recompte visual s actualitza despres de la resposta del backend
+
+## 4. Upload real de foto de perfil
+
+Fitxers:
+
+- `frontend/src/components/EditProfileModal.vue`
+- `frontend/src/views/ProfileView.vue`
+
+Abans:
+
+- el modal convertia la imatge seleccionada a `data:`
+- el valor es passava dins `fotoPerfil`
+- el backend nou rebutja valors que comencin per `data:`
+
+Ara:
+
+- el modal guarda el fitxer seleccionat en estat local
+- mostra preview amb `URL.createObjectURL`
+- `ProfileView.vue` rep el fitxer
+- si hi ha fitxer, primer fa:
+  - `POST /uploads/users`
+- amb la URL retornada fa:
+  - `PUT /users/:id`
+
+Flux final:
+
+1. usuari tria imatge al modal
+2. frontend mostra preview local
+3. frontend puja fitxer a `/uploads/users`
+4. backend retorna una ruta tipus `/uploads/users/fitxer.jpg`
+5. frontend desa aquesta ruta a `fotoPerfil`
+
+## 5. Vista `/cerca`
+
+Fitxer:
+
+- `frontend/src/views/SearchView.vue`
+
+Abans:
+
+- la vista nomes mostrava el text `Cerca`
+- no feia cap crida al backend
+
+Ara:
+
+- carrega resultats amb `GET /peaks`
+- permet filtrar per:
+  - text lliure
+  - comarca
+  - dificultat
+  - zona protegida
+  - altitud minima
+  - altitud maxima
+
+Contracte usat:
+
+- `GET /peaks?search=...`
+- `GET /peaks?comarca=...`
+- `GET /peaks?dificultat=...`
+- `GET /peaks?zonaProtegida=...`
+- `GET /peaks?minAlcada=...&maxAlcada=...`
+
+La vista mostra:
+
+- estat de carrega
+- estat d error
+- estat buit
+- llistat de cims amb imatge, metadades i enllaç a `/cim/:id`
+
+## 6. Logout connectat
+
+Fitxer:
+
+- `frontend/src/components/NavBar.vue`
+
+Abans:
+
+- logout nomes feia `userStore.logout()`
+- es netejava localStorage, pero no es cridava backend
+
+Ara:
+
+- abans de netejar sessio local, intenta fer:
+  - `POST /auth/logout`
+
+Com que el backend fa logout stateless, si aquesta crida falla igualment es neteja la sessio local per no bloquejar l usuari.
+
+## 7. Correccio de publicacions: `isAdmin`
+
+Fitxer:
+
+- `backend/src/modules/publicacions/publicacions.controller.js`
+
+Problema:
+
+- `updatePublicacio` cridava:
+
+```js
+updatePublication(publicationId, userId, payload, isAdmin)
+```
+
+- pero `isAdmin` no estava definit dins la funcio
+
+Canvi aplicat:
+
+```js
+const isAdmin = req.auth && req.auth.rol === 'admin';
+```
+
+Resultat:
+
+- `PUT /publicacions/:id` ja pot passar correctament el rol admin al service
+- s evita un `ReferenceError: isAdmin is not defined`
+
+## 8. Migracio de `tipusRecorregut`
+
+Fitxer:
+
+- `backend/migrations/20260517174530_admin_endpoints_sync/migration.sql`
+
+Contingut:
+
+```sql
+ALTER TABLE "RutaPlanificada" ALTER COLUMN "tipusRecorregut" DROP DEFAULT;
+```
+
+Context:
+
+- una migracio anterior havia creat `tipusRecorregut` amb default `'circular'`
+- el `schema.prisma` actual defineix:
+
+```prisma
+tipusRecorregut String
+```
+
+sense `@default`.
+
+Per tant, aquesta migracio sincronitza la base de dades amb el schema actual.
+
+Important:
+
+- no s ha executat cap migracio durant aquesta integracio
+- aquesta migracio no crea admin
+- tot i el nom `admin_endpoints_sync`, realment afecta `RutaPlanificada`
+
+## 9. Que queda connectat ara
+
+### Frontend amb backend
+
+- Login: `POST /auth/login`
+- Registre: `POST /auth/register`
+- Logout: `POST /auth/logout`
+- Home cims: `GET /peaks`
+- Fitxa cim: `GET /peaks/:id`
+- Guardar cim: `POST /peaks/:id/saved`
+- Treure cim guardat: `DELETE /peaks/:id/saved`
+- Estat cim guardat: `GET /peaks/:id/saved`
+- Perfil propi: `GET /users/:id`
+- Cims guardats perfil: `GET /users/:id/saved`
+- Likes perfil: `GET /users/:id/likes`
+- Rutes perfil: `GET /users/:id/routes`
+- Foto perfil: `POST /uploads/users` + `PUT /users/:id`
+- Cerca: `GET /peaks` amb filtres
+- Crear publicacio: `POST /uploads/publicacions` + `POST /publicacions`
+- Publicacio detall: `GET /publicacions/:id`
+- Comentaris: `POST /publicacions/:id/comments` i `DELETE /comments/:id`
+- Likes: `POST /publicacions/:id/likes` i `DELETE /publicacions/:id/likes`
+- Planificador: `POST /routes`
+- Admin: `/admin/comments`, `/admin/publicacions`, `/admin/users`
+
+## 10. Proves manuals recomanades
+
+### Auth
+
+1. Registrar usuari nou.
+2. Fer login.
+3. Fer logout i comprovar que torna a Home.
+
+### Home i cims guardats
+
+1. Entrar autenticat a Home.
+2. Guardar un cim.
+3. Recarregar la pagina.
+4. Comprovar que el cim continua guardat.
+5. Anar al perfil i comprovar que apareix a "Cims guardats".
+6. Treure el cim de guardats.
+
+### Perfil i foto
+
+1. Obrir perfil propi.
+2. Editar perfil.
+3. Seleccionar una foto del dispositiu.
+4. Guardar.
+5. Comprovar que navbar i perfil mostren la foto nova.
+
+### Cerca
+
+1. Entrar a `/cerca`.
+2. Cercar per text.
+3. Filtrar per comarca.
+4. Filtrar per dificultat.
+5. Filtrar per altitud.
+6. Obrir una fitxa de cim des dels resultats.
+
+### Publicacions
+
+1. Crear una publicacio.
+2. Obrir el detall.
+3. Afegir comentari.
+4. Fer like i treure like.
+5. Si s edita una publicacio, comprovar que no apareix l error de `isAdmin`.
+
+### Admin
+
+1. Entrar amb usuari admin.
+2. Obrir `/admin`.
+3. Crear/editar/eliminar cim.
+4. Consultar comentaris, publicacions i usuaris.
+5. Eliminar comentari o publicacio de prova.
+6. Canviar rol d un usuari de prova.
+
+## 11. Notes i decisions
+
+- No s ha fet commit automaticament durant la implementacio.
+- No s han executat migracions.
+- No s ha executat seed.
+- No s ha actualitzat la documentacio antiga del projecte.
+- Els mocks antics encara existeixen, pero algunes funcionalitats ja consumeixen backend real.
+- La carpeta admin s ha afegit a Git perquè `app.js` ja la importa.
+- La migracio nova s ha afegit a Git perquè el schema actual no defineix default per `tipusRecorregut`.
+
+## 12. Pendent posterior
+
+- Revisar amb l equip si es vol mantenir la migracio amb aquest nom o regenerar-la amb un nom mes descriptiu.
+- Decidir si es netegen mocks antics.
+- Unificar nomenclatura `/uploads/usuaris` i `/uploads/users`.
+- Actualitzar docs antics quan el company confirmi l estat final.
+- Executar proves manuals completes abans de mergejar a `main`.
+
+Fi del document.

--- a/docs/CIMSCAT_PULIR_DETALLS.md
+++ b/docs/CIMSCAT_PULIR_DETALLS.md
@@ -1,0 +1,207 @@
+# CIMSCAT PULIR DETALLS
+
+## Objectiu
+
+Documentar els ajustos finals aplicats al frontend per deixar l'aplicacio mes coherent visualment, mes clara per a l'usuari i mes propera a les pantalles previstes al disseny del projecte.
+
+Aquest document recull canvis de polit i millora d'experiencia d'usuari. No inclou canvis de backend, Prisma, migracions ni seeds.
+
+## Context funcional
+
+Durant la revisio final del projecte es van detectar diversos detalls visuals i de navegacio que podien millorar-se abans de tancar la versio. La major part dels canvis estaven relacionats amb:
+
+- textos i accents en catala
+- ordre i claredat dels formularis
+- coherencia entre targetes i carrusels
+- connexio visual entre mapa i llistats
+- simplificacio d'elements duplicats
+- millora de la vista de planificacio de rutes
+
+L'objectiu ha estat mantenir la funcionalitat ja existent, pero polir la presentacio per fer que l'aplicacio sembli mes acabada i mes facil d'utilitzar.
+
+## Fitxers modificats
+
+### Frontend
+
+- `frontend/src/components/AdminPeakModal.vue`
+- `frontend/src/components/NavBar.vue`
+- `frontend/src/components/PeakCard.vue`
+- `frontend/src/views/AdminDashboard.vue`
+- `frontend/src/views/CreatePublicationView.vue`
+- `frontend/src/views/HomeView.vue`
+- `frontend/src/views/PeakDetailView.vue`
+- `frontend/src/views/PlanRouteView.vue`
+- `frontend/src/views/ProfileView.vue`
+- `frontend/src/views/PublicationView.vue`
+
+## 1. Ajustos de navegacio i navbar
+
+S'ha simplificat la navegacio superior per evitar elements duplicats o poc clars.
+
+Canvis principals:
+
+- s'ha eliminat el boto negre amb el nom d'usuari quan ja hi havia l'avatar circular que porta al perfil
+- en usuaris administradors, s'ha mantingut l'acces al panell i s'han amagat accions que no corresponen al rol admin, com crear publicacions o planificar rutes
+- s'ha canviat el text `Admin` per `Panell`
+- s'han corregit textos com `Tancar sessio` per `Tancar sessió`
+
+Resultat:
+
+- la navbar queda mes neta
+- l'acces al perfil es manté amb l'avatar
+- el rol admin queda separat del flux normal d'usuari
+
+## 2. Home: connexio entre mapa i cims destacats
+
+A la Home s'ha millorat la relacio entre el mapa i el llistat de cims destacats.
+
+Abans:
+
+- el mapa mostrava els marcadors dels cims
+- el llistat de l'esquerra funcionava de manera independent
+- si es clicava un marcador, no sempre quedava clar quin cim corresponia al llistat
+
+Ara:
+
+- quan es clica una card de cim, el mapa se centra en aquell cim i obre el marcador corresponent
+- quan es clica un marcador del mapa, la card del cim es ressalta i el llistat fa scroll fins deixar-la visible
+- el marcador seleccionat es mostra mes destacat visualment
+
+Resultat:
+
+- el mapa i el llistat treballen junts
+- l'usuari pot localitzar mes facilment un cim concret
+- la Home queda mes interactiva i mes coherent
+
+## 3. Fitxa de cim
+
+S'ha ajustat la fitxa de cim per acostar-la mes al disseny previst.
+
+Canvis principals:
+
+- s'ha eliminat dependencia de dades mock quan no calia
+- s'ha donat mes pes a la informacio oficial del cim
+- s'han tret estadistiques internes de la part tecnica quan no aportaven valor a la fitxa publica
+- s'ha reorganitzat el contingut per semblar mes una fitxa professional
+- s'han mantingut espais buits quan encara no hi ha dades reals, en comptes d'omplir amb informacio inventada
+
+Resultat:
+
+- la fitxa mostra millor el cim com a element oficial de la plataforma
+- les publicacions relacionades queden separades de les dades tecniques
+- la pantalla queda mes clara i menys carregada
+
+## 4. Formulari de creacio de publicacions
+
+La vista de crear publicacio s'ha revisat per millorar ordre, textos i coherencia.
+
+Canvis principals:
+
+- s'ha mantingut el camp `Dificultat`, ja que continua formant part del contracte real de publicacio
+- s'ha eliminat el camp visible d'enllac manual del track
+- s'ha mogut la seleccio de rutes guardades a la part inferior del formulari, just abans de `Track i mapa`
+- s'ha canviat `Ruta planificada vinculada` per `Rutes guardades`
+- s'ha eliminat el boto `Recarregar rutes` i el recompte visual de rutes disponibles
+- s'ha simplificat el format del temps estimat a `h:mm`
+- s'han corregit textos i accents
+
+Resultat:
+
+- el formulari queda mes ordenat
+- la ruta guardada queda mes ben situada dins el flux de publicacio
+- el temps estimat es demana amb un format mes clar
+
+## 5. Planificador de rutes
+
+La vista del planificador s'ha modificat per apropar-la al wireframe previst inicialment.
+
+Canvis visuals:
+
+- s'ha tret el text superior `Planificador de rutes`
+- s'ha mantingut el titol principal `Planificar Ruta`
+- s'ha afegit un buscador visual de cim, comarca o ruta
+- s'ha ampliat el mapa com a element principal
+- s'ha col.locat el panell `La teva ruta` sobre el mapa
+- s'ha afegit una fitxa tecnica inferior amb dades resumides
+- s'ha evitat afegir una seccio de comentaris, ja que no formava part de l'abast final
+
+Canvis funcionals de frontend:
+
+- quan l'usuari selecciona un cim principal, el mapa s'apropa automaticament a aquell cim si te coordenades
+- el planificador pot carregar una ruta existent mitjancant `routeId` a la URL
+- si s'obre una ruta existent des del perfil, es carreguen el cim, el nom, el tipus d'activitat, el ritme, el tipus de recorregut i els punts
+- el boto passa de `Guardar ruta` a `Guardar canvis` quan s'esta editant una ruta existent
+
+Resultat:
+
+- la pantalla s'assembla mes al disseny plantejat
+- l'usuari no ha de buscar manualment el cim al mapa
+- una ruta planificada es pot recuperar i modificar des del frontend utilitzant els endpoints ja existents
+
+## 6. Perfil: rutes planificades i carrusels
+
+S'ha revisat la seccio de perfil per fer que les rutes planificades encaixin millor amb la resta de carrusels.
+
+Canvis principals:
+
+- s'han eliminat textos descriptius sobrants sota alguns titols
+- les targetes de rutes planificades tenen el mateix estil base que les altres targetes
+- s'ha canviat el fons de les rutes a blanc per unificar el disseny
+- s'ha ajustat l'alcada de les targetes per evitar espai buit excessiu
+- s'ha afegit el boto `Veure ruta`
+- el boto porta al planificador amb la ruta carregada
+
+Resultat:
+
+- la seccio `Rutes planificades` queda visualment mes coherent
+- l'usuari pot tornar a una ruta ja guardada
+- es pot modificar una ruta existent sense crear una pantalla nova
+
+## 7. Panell d'administracio
+
+S'han polit textos del panell d'administracio per mantenir coherencia lingüistica.
+
+Canvis principals:
+
+- `administracio` passa a `administració`
+- `moderacio` passa a `moderació`
+- `publicacio` passa a `publicació`
+- `cataleg` passa a `catàleg`
+
+Resultat:
+
+- el panell queda mes cuidat
+- es redueixen barreges o errors de llengua visibles a la interfície
+
+## 8. Limitacions i abast
+
+Aquests canvis s'han fet nomes al frontend.
+
+No s'ha modificat:
+
+- backend
+- endpoints
+- Prisma
+- migracions
+- seeds
+- base de dades
+
+La part de planificacio avanzada de tracks, com ara calcul real de rutes per camins, superficies, desnivell fiable o perfil d'elevacio real, queda fora d'aquest bloc de polit. Aquesta funcionalitat requeriria una integracio posterior amb motors de routing o serveis externs de mapes i elevacio.
+
+## 9. Validacio
+
+Despres dels canvis s'ha executat:
+
+```bash
+npm run build
+```
+
+Resultat:
+
+- el frontend compila correctament
+- no s'han detectat errors de build
+
+## 10. Resum final
+
+Aquest bloc de treball ha servit per acabar de polir la part visual i funcional del frontend. Els canvis no introdueixen nous models de dades ni modifiquen el backend, pero milloren la percepcio final de l'aplicacio: navegacio mes clara, formularis mes ordenats, perfil mes coherent, planificador mes proper al disseny previst i millor connexio entre mapa i contingut.
+

--- a/frontend/src/components/AdminPeakModal.vue
+++ b/frontend/src/components/AdminPeakModal.vue
@@ -10,71 +10,109 @@
       </header>
 
       <form class="admin-peak-modal__form" @submit.prevent="handleSubmit">
-        <div class="admin-peak-modal__grid">
-          <label class="admin-peak-modal__field">
-            <span>Nom</span>
-            <input v-model.trim="form.nom" type="text" />
-          </label>
+        <div class="admin-peak-modal__body">
+          <div class="admin-peak-modal__content">
+            <section class="admin-peak-modal__section">
+              <div class="admin-peak-modal__section-heading">
+                <p>Dades bàsiques</p>
+                <small>Informació principal que es mostrarà a la fitxa pública del cim.</small>
+              </div>
 
-          <label class="admin-peak-modal__field">
-            <span>Comarca</span>
-            <input v-model.trim="form.comarca" type="text" />
-          </label>
+              <div class="admin-peak-modal__grid">
+                <label class="admin-peak-modal__field">
+                  <span>Nom</span>
+                  <input v-model.trim="form.nom" type="text" placeholder="Aneto" />
+                </label>
 
-          <label class="admin-peak-modal__field">
-            <span>Massís</span>
-            <input v-model.trim="form.massis" type="text" />
-          </label>
+                <label class="admin-peak-modal__field">
+                  <span>Comarca o zona</span>
+                  <input v-model.trim="form.comarca" type="text" placeholder="Vall de Benasc" />
+                </label>
 
-          <label class="admin-peak-modal__field">
-            <span>Dificultat</span>
-            <input v-model.trim="form.dificultat" type="text" />
-          </label>
+                <label class="admin-peak-modal__field">
+                  <span>Massís</span>
+                  <input v-model.trim="form.massis" type="text" placeholder="Posets-Aneto" />
+                </label>
 
-          <label class="admin-peak-modal__field">
-            <span>Altitud</span>
-            <input v-model.number="form.alcada" type="number" min="0" step="1" />
-          </label>
+                <label class="admin-peak-modal__field">
+                  <span>Dificultat</span>
+                  <input v-model.trim="form.dificultat" type="text" placeholder="alta" />
+                </label>
+              </div>
+            </section>
 
-          <label class="admin-peak-modal__field">
-            <span>Latitud</span>
-            <input v-model.number="form.lat" type="number" step="0.000001" />
-          </label>
+            <section class="admin-peak-modal__section">
+              <div class="admin-peak-modal__section-heading">
+                <p>Localització</p>
+                <small>Les coordenades accepten punt o coma decimal.</small>
+              </div>
 
-          <label class="admin-peak-modal__field">
-            <span>Longitud</span>
-            <input v-model.number="form.lon" type="number" step="0.000001" />
-          </label>
+              <div class="admin-peak-modal__grid admin-peak-modal__grid--three">
+                <label class="admin-peak-modal__field">
+                  <span>Altitud</span>
+                  <input v-model="form.alcada" inputmode="numeric" type="text" placeholder="3404" />
+                </label>
 
-          <label class="admin-peak-modal__field">
-            <span>Zona protegida</span>
-            <input v-model.trim="form.zonaProtegida" type="text" placeholder="Opcional" />
-          </label>
-        </div>
+                <label class="admin-peak-modal__field">
+                  <span>Latitud</span>
+                  <input v-model.trim="form.lat" inputmode="decimal" type="text" placeholder="42.6311" />
+                </label>
 
-        <label class="admin-peak-modal__field admin-peak-modal__field--full">
-          <span>Descripcio</span>
-          <textarea v-model.trim="form.descripcio" rows="5" />
-        </label>
+                <label class="admin-peak-modal__field">
+                  <span>Longitud</span>
+                  <input v-model.trim="form.lon" inputmode="decimal" type="text" placeholder="0.6566" />
+                </label>
+              </div>
 
-        <div class="admin-peak-modal__upload">
-          <div class="admin-peak-modal__upload-copy">
-            <span>Imatge del cim</span>
-            <small>Pots pujar una imatge nova o mantenir la ruta actual.</small>
+              <label class="admin-peak-modal__field admin-peak-modal__field--full">
+                <span>Zona protegida</span>
+                <input
+                  v-model.trim="form.zonaProtegida"
+                  type="text"
+                  placeholder="Parc Natural Posets-Maladeta"
+                />
+              </label>
+            </section>
+
+            <section class="admin-peak-modal__section">
+              <div class="admin-peak-modal__section-heading">
+                <p>Descripció de la fitxa</p>
+                <small>Text públic del cim. Es pot deixar breu i professional.</small>
+              </div>
+
+              <label class="admin-peak-modal__field admin-peak-modal__field--full">
+                <span>Descripció</span>
+                <textarea
+                  v-model.trim="form.descripcio"
+                  rows="6"
+                  placeholder="L'Aneto és el cim més alt dels Pirineus i una de les ascensions més emblemàtiques de l'alta muntanya pirinenca."
+                />
+              </label>
+            </section>
           </div>
 
-          <div class="admin-peak-modal__upload-actions">
-            <input ref="fileInput" type="file" accept="image/*" @change="handleFileChange" />
-            <input
-              v-model.trim="form.imatgeUrl"
-              type="text"
-              placeholder="/uploads/peaks/nom-fitxer.jpg"
-            />
-          </div>
-        </div>
+          <aside class="admin-peak-modal__media-panel">
+            <div class="admin-peak-modal__media-copy">
+              <p>Imatge del cim</p>
+              <small>Puja una imatge nova o mantén la ruta actual.</small>
+            </div>
 
-        <div v-if="previewImage" class="admin-peak-modal__preview">
-          <img :src="previewImage" :alt="form.nom || 'Previsualitzacio del cim'" />
+            <div v-if="previewImage" class="admin-peak-modal__preview">
+              <img :src="previewImage" :alt="form.nom || 'Previsualitzacio del cim'" />
+            </div>
+            <div v-else class="admin-peak-modal__preview admin-peak-modal__preview--empty">
+              Sense imatge seleccionada
+            </div>
+
+            <div class="admin-peak-modal__upload-actions">
+              <input ref="fileInput" type="file" accept="image/*" @change="handleFileChange" />
+              <input
+                v-model.trim="form.imatgeUrl"
+                type="text"
+                placeholder="/uploads/peaks/aneto.jpg"
+              />
+            </div>
+          </aside>
         </div>
 
         <p v-if="errorMessage" class="admin-peak-modal__error">{{ errorMessage }}</p>
@@ -171,9 +209,9 @@ function validateForm() {
   }
 
   const requiredNumbers = [
-    ['alcada', form.alcada],
-    ['lat', form.lat],
-    ['lon', form.lon],
+    ['alcada', parseLocaleNumber(form.alcada)],
+    ['lat', parseLocaleNumber(form.lat)],
+    ['lon', parseLocaleNumber(form.lon)],
   ]
 
   const invalidNumberField = requiredNumbers.find(([, value]) => !Number.isFinite(Number(value)))
@@ -190,6 +228,12 @@ function validateForm() {
   return true
 }
 
+function parseLocaleNumber(value) {
+  if (typeof value === 'number') return value
+  const normalized = String(value || '').trim().replace(',', '.')
+  return Number(normalized)
+}
+
 function handleFileChange(event) {
   selectedFile.value = event.target.files?.[0] || null
   errorMessage.value = ''
@@ -204,9 +248,9 @@ function handleSubmit() {
       comarca: form.comarca.trim(),
       massis: form.massis.trim(),
       dificultat: form.dificultat.trim(),
-      alcada: Number(form.alcada),
-      lat: Number(form.lat),
-      lon: Number(form.lon),
+      alcada: parseLocaleNumber(form.alcada),
+      lat: parseLocaleNumber(form.lat),
+      lon: parseLocaleNumber(form.lon),
       descripcio: form.descripcio.trim(),
       imatgeUrl: form.imatgeUrl.trim(),
       zonaProtegida: form.zonaProtegida.trim(),
@@ -236,7 +280,7 @@ watch(
 }
 
 .admin-peak-modal {
-  width: min(100%, 880px);
+  width: min(100%, 1080px);
   max-height: calc(100vh - 2rem);
   overflow: auto;
   background: #fff;
@@ -277,13 +321,58 @@ watch(
   margin-top: 1rem;
   display: flex;
   flex-direction: column;
+  gap: 1.15rem;
+}
+
+.admin-peak-modal__body {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 330px;
+  gap: 1.25rem;
+  align-items: start;
+}
+
+.admin-peak-modal__content {
+  display: flex;
+  flex-direction: column;
   gap: 1rem;
+}
+
+.admin-peak-modal__section,
+.admin-peak-modal__media-panel {
+  border: 1px solid #d4d4ce;
+  border-radius: 14px;
+  background: #fff;
+  padding: 1rem;
+}
+
+.admin-peak-modal__section-heading,
+.admin-peak-modal__media-copy {
+  margin-bottom: 0.85rem;
+}
+
+.admin-peak-modal__section-heading p,
+.admin-peak-modal__media-copy p {
+  margin: 0;
+  font-weight: 700;
+  color: var(--color-text);
+}
+
+.admin-peak-modal__section-heading small,
+.admin-peak-modal__media-copy small {
+  display: block;
+  margin-top: 0.25rem;
+  color: var(--color-text-soft);
+  line-height: 1.4;
 }
 
 .admin-peak-modal__grid {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 1rem;
+  gap: 0.9rem;
+}
+
+.admin-peak-modal__grid--three {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
 }
 
 .admin-peak-modal__field {
@@ -306,37 +395,47 @@ watch(
   background: #fff;
 }
 
-.admin-peak-modal__upload {
-  padding: 1rem;
-  border-radius: 14px;
-  background: #f7f6f1;
-  border: 1px solid var(--color-border);
-  align-items: flex-start;
-}
-
-.admin-peak-modal__upload-copy {
-  display: flex;
-  flex-direction: column;
-  gap: 0.25rem;
+.admin-peak-modal__field input::placeholder,
+.admin-peak-modal__field textarea::placeholder,
+.admin-peak-modal__upload-actions input::placeholder {
+  color: #aaa9a3;
 }
 
 .admin-peak-modal__upload-actions {
   display: flex;
   flex-direction: column;
   gap: 0.7rem;
-  min-width: min(100%, 320px);
 }
 
 .admin-peak-modal__upload-actions input[type='file'] {
   font: inherit;
 }
 
+.admin-peak-modal__upload-actions input[type='text'] {
+  width: 100%;
+  border: 1px solid var(--color-border);
+  border-radius: 10px;
+  padding: 0.65rem 0.75rem;
+  font: inherit;
+}
+
 .admin-peak-modal__preview img {
   width: 100%;
-  max-height: 260px;
+  aspect-ratio: 4 / 3;
+  height: auto;
   object-fit: cover;
   border-radius: 14px;
   border: 1px solid var(--color-border);
+}
+
+.admin-peak-modal__preview--empty {
+  display: grid;
+  min-height: 220px;
+  place-items: center;
+  border-radius: 14px;
+  border: 1px dashed #bbb9b2;
+  background: #f8f7f3;
+  color: var(--color-text-soft);
 }
 
 .admin-peak-modal__error {
@@ -363,12 +462,21 @@ watch(
   border-color: var(--color-button-primary);
 }
 
+@media (max-width: 900px) {
+  .admin-peak-modal__body {
+    grid-template-columns: 1fr;
+  }
+
+  .admin-peak-modal__media-panel {
+    order: -1;
+  }
+}
+
 @media (max-width: 700px) {
   .admin-peak-modal__grid {
     grid-template-columns: 1fr;
   }
 
-  .admin-peak-modal__upload,
   .admin-peak-modal__header,
   .admin-peak-modal__footer {
     flex-direction: column;

--- a/frontend/src/components/NavBar.vue
+++ b/frontend/src/components/NavBar.vue
@@ -81,23 +81,20 @@
 
     <div class="navbar-right">
       <!-- Aquest botó canvia de ruta segons si l'usuari està loguejat o no. -->
-      <RouterLink :to="planRouteLink" class="btn-plan">Planificar nova ruta</RouterLink>
+      <RouterLink v-if="!userStore.isAdmin" :to="planRouteLink" class="btn-plan">Planificar nova ruta</RouterLink>
 
       <!-- Si l'usuari està autenticat, mostrem el seu nom i un botó d'icona. -->
       <template v-if="userStore.isAuthenticated">
-        <RouterLink to="/crear-publicacio" class="btn-create-publication">
+        <RouterLink v-if="!userStore.isAdmin" to="/crear-publicacio" class="btn-create-publication">
           Crear publicació
         </RouterLink>
         <RouterLink v-if="userStore.isAdmin" to="/admin" class="btn-admin">
-          Admin
+          Panell
         </RouterLink>
         <button class="btn-logout" type="button" @click="handleLogout">
-          Tancar sessio
+          Tancar sessió
         </button>
-        <RouterLink :to="`/perfil/${userStore.user?.id}`" class="btn-profile__name-link">
-          <span class="btn-profile__name">{{ userStore.user?.nomUsuari }}</span>
-        </RouterLink>
-        <RouterLink :to="`/perfil/${userStore.user?.id}`" class="btn-profile">
+        <RouterLink v-if="!userStore.isAdmin" :to="`/perfil/${userStore.user?.id}`" class="btn-profile">
           <img
             v-if="profileImage"
             :src="profileImage"
@@ -148,14 +145,22 @@
     </div>
 
     <div v-if="userStore.isAuthenticated && isMobileMenuOpen" class="navbar-mobile-menu">
-      <RouterLink :to="planRouteLink" class="navbar-mobile-menu__link" @click="closeMobilePanels">
+      <RouterLink
+        v-if="userStore.isAdmin"
+        to="/admin"
+        class="navbar-mobile-menu__link"
+        @click="closeMobilePanels"
+      >
+        Panell
+      </RouterLink>
+      <RouterLink v-if="!userStore.isAdmin" :to="planRouteLink" class="navbar-mobile-menu__link" @click="closeMobilePanels">
         Planificar nova ruta
       </RouterLink>
-      <RouterLink to="/crear-publicacio" class="navbar-mobile-menu__link" @click="closeMobilePanels">
+      <RouterLink v-if="!userStore.isAdmin" to="/crear-publicacio" class="navbar-mobile-menu__link" @click="closeMobilePanels">
         Crear publicació
       </RouterLink>
       <button class="navbar-mobile-menu__link navbar-mobile-menu__link--button" type="button" @click="handleLogout">
-        Tancar sessio
+        Tancar sessió
       </button>
     </div>
   </nav>
@@ -210,7 +215,7 @@ const profileImage = computed(() =>
 
 async function handleLogout() {
   // Abans de tancar la sessió, demanem confirmació per no fer logout accidentalment.
-  const confirmed = window.confirm('Vols tancar sessio?')
+  const confirmed = window.confirm('Vols tancar sessió?')
 
   if (!confirmed) return
 

--- a/frontend/src/components/PeakCard.vue
+++ b/frontend/src/components/PeakCard.vue
@@ -31,7 +31,7 @@
           :title="isSaved ? 'Treure de guardats' : 'Guardar cim'"
           :data-tooltip="isSaved ? 'Treure de guardats' : 'Guardar cim'"
           :disabled="isSaving"
-          @click="handleSave"
+          @click.stop="handleSave"
         >
           <svg viewBox="0 0 24 24" aria-hidden="true">
             <path
@@ -45,8 +45,8 @@
       <p class="peak-card__excerpt">{{ publication.excerpt }}</p>
 
       <!-- Enllaç cap a la fitxa del cim. -->
-      <RouterLink :to="`/cim/${publication.peakId}`" class="peak-card__link">
-        Veure pagina del cim
+      <RouterLink :to="`/cim/${publication.peakId}`" class="peak-card__link" @click.stop>
+        Veure pàgina del cim
       </RouterLink>
     </div>
   </article>

--- a/frontend/src/views/AdminDashboard.vue
+++ b/frontend/src/views/AdminDashboard.vue
@@ -1,7 +1,7 @@
 <template>
   <section class="admin-dashboard">
     <div v-if="isLoading" class="admin-feedback">
-      Carregant dades reals del panell d&apos;administracio...
+      Carregant dades reals del panell d&apos;administració...
     </div>
 
     <div v-else-if="errorMessage" class="admin-feedback admin-feedback--error">
@@ -10,7 +10,7 @@
 
     <header class="admin-dashboard__header">
       <div>
-        <p class="admin-dashboard__eyebrow">Panell d'administracio</p>
+        <p class="admin-dashboard__eyebrow">Panell d'administració</p>
         <h1>Gestio de plataforma</h1>
       </div>
 
@@ -93,11 +93,11 @@
       </div>
 
       <label class="admin-search">
-        <span>Cerca global moderacio</span>
+        <span>Cerca global de moderació</span>
         <input
           v-model.trim="moderationSearchQuery"
           type="text"
-          placeholder="Usuari, publicacio, comentari o paraula..."
+          placeholder="Usuari, publicació, comentari o paraula..."
         />
       </label>
 
@@ -105,7 +105,7 @@
         Comentaris: {{ adminComments.length }} · Publicacions: {{ adminPublicacions.length }} · Usuaris: {{ adminUsers.length }}
       </p>
 
-      <div v-if="isLoadingModeration" class="admin-feedback">Carregant moderacio...</div>
+      <div v-if="isLoadingModeration" class="admin-feedback">Carregant moderació...</div>
       <div v-else-if="moderationError" class="admin-feedback admin-feedback--error">{{ moderationError }}</div>
       <div v-else class="moderation-live">
         <div class="moderation-live__block">
@@ -269,7 +269,7 @@ async function fetchPeaks() {
     peaks.value = data.peaks || []
   } catch (error) {
     peaks.value = []
-    errorMessage.value = getApiErrorMessage(error, 'No hem pogut carregar el cataleg de cims.')
+    errorMessage.value = getApiErrorMessage(error, 'No hem pogut carregar el catàleg de cims.')
   } finally {
     isLoading.value = false
   }
@@ -294,7 +294,7 @@ async function fetchModerationData() {
     adminComments.value = []
     adminPublicacions.value = []
     adminUsers.value = []
-    moderationError.value = getApiErrorMessage(error, 'No hem pogut carregar la moderacio admin.')
+    moderationError.value = getApiErrorMessage(error, 'No hem pogut carregar la moderació del panell.')
   } finally {
     isLoadingModeration.value = false
   }
@@ -379,13 +379,13 @@ async function handleCommentDelete(comment) {
 }
 
 async function handlePublicationDelete(publication) {
-  if (!window.confirm(`Vols eliminar la publicacio "${publication.titol}"?`)) return
+  if (!window.confirm(`Vols eliminar la publicació "${publication.titol}"?`)) return
 
   try {
     await api.delete(`/admin/publicacions/${publication.id}`)
     await fetchModerationData()
   } catch (error) {
-    window.alert(getApiErrorMessage(error, 'No hem pogut eliminar la publicacio.'))
+    window.alert(getApiErrorMessage(error, 'No hem pogut eliminar la publicació.'))
   }
 }
 

--- a/frontend/src/views/CreatePublicationView.vue
+++ b/frontend/src/views/CreatePublicationView.vue
@@ -48,45 +48,6 @@
             </label>
 
             <label class="create-publication-field">
-              <span>Ruta planificada vinculada</span>
-              <select
-                v-model="form.rutaPlanificadaId"
-                :disabled="!userStore.isAuthenticated || isLoadingRoutes"
-              >
-                <option value="">Sense ruta vinculada</option>
-                <option v-for="route in userRoutes" :key="route.id" :value="route.id">
-                  {{ formatRouteLabel(route) }}
-                </option>
-              </select>
-              <small v-if="!userStore.isAuthenticated" class="create-publication-route-note">
-                Inicia sessio per veure les teves rutes planificades.
-              </small>
-              <small v-else-if="routesError" class="create-publication-route-note create-publication-route-note--error">
-                {{ routesError }}
-              </small>
-              <small
-                v-else-if="userStore.isAuthenticated && !isLoadingRoutes && !userRoutes.length"
-                class="create-publication-route-note"
-              >
-                No tens rutes disponibles. Desa una ruta al planificador i torna aquí.
-              </small>
-              <small
-                v-else-if="userStore.isAuthenticated && userRoutes.length"
-                class="create-publication-route-note"
-              >
-                {{ userRoutes.length }} rutes disponibles per vincular.
-              </small>
-              <button
-                v-if="userStore.isAuthenticated"
-                class="create-publication-route-refresh"
-                type="button"
-                @click="fetchUserRoutes"
-              >
-                Recarregar rutes
-              </button>
-            </label>
-
-            <label class="create-publication-field">
               <span>Dificultat</span>
               <input
                 v-model="form.dificultat"
@@ -100,14 +61,6 @@
               <input v-model="form.dataActivitat" type="date" />
             </label>
 
-            <label class="create-publication-field">
-              <span>Track URL</span>
-              <input
-                v-model="form.trackUrl"
-                type="url"
-                placeholder="https://..."
-              />
-            </label>
           </div>
         </section>
 
@@ -131,12 +84,12 @@
             </label>
 
             <label class="create-publication-field">
-              <span>Temps estimat</span>
+              <span>Temps estimat (h:mm)</span>
               <input
                 v-model="form.tempsEstimathhmm"
                 type="text"
                 inputmode="numeric"
-                placeholder="Ex. 02:00 o 02:00:00"
+                placeholder="Ex. 02:30"
               />
             </label>
 
@@ -194,6 +147,35 @@
               </button>
             </article>
           </div>
+        </section>
+
+        <section class="create-publication-section">
+          <h2 class="create-publication-section__title">Rutes guardades</h2>
+
+          <label class="create-publication-field">
+            <span>Ruta guardada</span>
+            <select
+              v-model="form.rutaPlanificadaId"
+              :disabled="!userStore.isAuthenticated || isLoadingRoutes"
+            >
+              <option value="">Sense ruta guardada</option>
+              <option v-for="route in userRoutes" :key="route.id" :value="route.id">
+                {{ formatRouteLabel(route) }}
+              </option>
+            </select>
+            <small v-if="!userStore.isAuthenticated" class="create-publication-route-note">
+              Inicia sessió per veure les teves rutes guardades.
+            </small>
+            <small v-else-if="routesError" class="create-publication-route-note create-publication-route-note--error">
+              {{ routesError }}
+            </small>
+            <small
+              v-else-if="userStore.isAuthenticated && !isLoadingRoutes && !userRoutes.length"
+              class="create-publication-route-note"
+            >
+              Encara no tens cap ruta guardada. Desa’n una al planificador i torna aquí.
+            </small>
+          </label>
         </section>
 
         <section class="create-publication-section">
@@ -316,12 +298,12 @@ const selectedRoute = computed(() =>
 )
 
 const selectedRouteSummaryTitle = computed(() =>
-  selectedRoute.value ? `Ruta vinculada: ${selectedRoute.value.nom}` : 'Cap ruta vinculada',
+  selectedRoute.value ? `Ruta guardada: ${selectedRoute.value.nom}` : 'Cap ruta guardada seleccionada',
 )
 
 const selectedRouteSummaryText = computed(() => {
   if (!selectedRoute.value) {
-    return 'Si vols vincular una ruta guardada, selecciona-la a la secció “Informació principal”.'
+    return 'Selecciona una ruta guardada per previsualitzar-la al mapa.'
   }
 
   const distance = Number(selectedRoute.value.distanciaKm || 0).toLocaleString('ca-ES', {
@@ -421,7 +403,7 @@ async function fetchSelectedRouteDetail(routeId) {
     selectedRouteDetail.value = data.route || null
   } catch (error) {
     selectedRouteDetail.value = null
-    selectedRouteError.value = getApiErrorMessage(error, 'No hem pogut carregar el mapa de la ruta vinculada.')
+    selectedRouteError.value = getApiErrorMessage(error, 'No hem pogut carregar el mapa de la ruta guardada.')
   }
 }
 
@@ -545,7 +527,7 @@ function validateForm() {
   })
 
   if (parsedTime === null || parsedTime <= 0) {
-    errors.push('El temps estimat ha de tenir format hh:mm o hh:mm:ss.')
+    errors.push('El temps estimat ha de tenir el format hh:mm, per exemple 02:30.')
   }
 
   if (
@@ -557,7 +539,7 @@ function validateForm() {
   }
 
   if (payload.trackUrl && !/^https?:\/\//i.test(payload.trackUrl.trim())) {
-    errors.push('Si informes Track URL, ha de començar per http:// o https://')
+    errors.push("Si informes l'enllaç del track, ha de començar per http:// o https://.")
   }
 
   validationErrors.value = errors
@@ -639,21 +621,20 @@ function formatFileSize(size) {
 }
 
 function parseTimeToMinutes(value) {
-  // L'usuari escriu el temps en format humà (hh:mm o hh:mm:ss),
+  // L'usuari escriu el temps en format humà (hh:mm),
   // però backend vol minuts. Aquesta funció fa la conversió.
   const normalized = value.trim()
   if (!normalized) return null
 
-  const match = normalized.match(/^(\d{1,2}):(\d{2})(?::(\d{2}))?$/)
+  const match = normalized.match(/^(\d{1,2}):(\d{2})$/)
   if (!match) return null
 
   const hours = Number(match[1])
   const minutes = Number(match[2])
-  const seconds = Number(match[3] || 0)
 
-  if (minutes > 59 || seconds > 59) return null
+  if (minutes > 59) return null
 
-  return hours * 60 + minutes + Math.ceil(seconds / 60)
+  return hours * 60 + minutes
 }
 
 onMounted(() => {

--- a/frontend/src/views/HomeView.vue
+++ b/frontend/src/views/HomeView.vue
@@ -14,14 +14,14 @@
           currentSlide ens diu quina imatge del llistat heroImages s'ha de mostrar.
           Amb :src fem que la imatge vagi canviant dinàmicament.
         -->
-        <img :src="heroImages[currentSlide]" alt="Paisatge de muntanya" class="hero__image" />
+        <img :src="heroSlides[currentSlide].image" alt="Paisatge de muntanya" class="hero__image" />
 
         <!--
           Aquesta capa fosca a sobre de la foto fa que el text es pugui llegir millor.
           Visualment actua com a overlay del hero.
         -->
         <div class="hero__overlay">
-          <p class="hero__subtitle">Explora cims, descobreix rutes i guarda les millors sortides.</p>
+          <p class="hero__subtitle">{{ heroSlides[currentSlide].text }}</p>
         </div>
       </div>
 
@@ -32,7 +32,7 @@
       <div class="hero__dots">
         <!-- Si l'usuari clica un punt, saltem directament a aquella imatge. -->
         <button
-          v-for="(image, index) in heroImages"
+          v-for="(slide, index) in heroSlides"
           :key="index"
           class="hero__dot"
           :class="{ 'hero__dot--active': index === currentSlide }"
@@ -43,6 +43,9 @@
       <!-- Títol principal de la home. -->
       <div class="hero__text-block">
         <h1 class="hero__title">CimsCat</h1>
+        <p class="hero__intro">
+          Una plataforma per descobrir cims, preparar sortides i compartir experiències de muntanya.
+        </p>
       </div>
     </section>
 
@@ -63,7 +66,7 @@
           Columna esquerra: cards destacades.
           Fem un v-for per reutilitzar el component PeakCard per cada publicació.
         -->
-        <div class="featured-section__cards">
+        <div ref="cardsContainer" class="featured-section__cards">
           <p v-if="isLoadingPeaks" class="featured-section__status">
             Carregant cims destacats...
           </p>
@@ -83,6 +86,10 @@
             v-for="publication in displayedPublications"
             :key="publication.id"
             :publication="publication"
+            class="featured-section__card"
+            :class="{ 'featured-section__card--selected': selectedPeakId === publication.peakId }"
+            :ref="(el) => setPeakCardRef(publication.peakId, el)"
+            @click="handleCardSelect(publication)"
           />
         </div>
 
@@ -115,26 +122,39 @@ import { resolveMediaUrl } from '../utils/media'
 
 // Aquest és un marcador personalitzat perquè el punt del mapa sigui més coherent amb l'estètica del projecte.
 // En lloc d'usar el marcador blau per defecte de Leaflet, construïm un petit "pin" verd.
-const peakIcon = L.divIcon({
-  className: '',
-  html: `<div style="
-    width: 32px; height: 32px;
-    background: #2d6a4f;
-    border: 3px solid #fff;
+function createPeakIcon(isSelected = false) {
+  const size = isSelected ? 42 : 32
+  const background = isSelected ? '#184f39' : '#2d6a4f'
+  const borderWidth = isSelected ? 4 : 3
+
+  return L.divIcon({
+    className: '',
+    html: `<div style="
+    width: ${size}px; height: ${size}px;
+    background: ${background};
+    border: ${borderWidth}px solid #fff;
     border-radius: 50% 50% 50% 0;
     transform: rotate(-45deg);
-    box-shadow: 0 2px 8px rgba(0,0,0,0.35);
+    box-shadow: 0 2px 12px rgba(0,0,0,0.42);
   "></div>`,
-  iconSize: [32, 32],
-  iconAnchor: [16, 32],
-  popupAnchor: [0, -34],
-})
+    iconSize: [size, size],
+    iconAnchor: [size / 2, size],
+    popupAnchor: [0, -size],
+  })
+}
+
+const peakIcon = createPeakIcon(false)
+const selectedPeakIcon = createPeakIcon(true)
 
 // Aquí preparem els cims destacats que volem mostrar a la home.
 // Les ordenem de més guardats a menys guardats perquè la home ha d'ensenyar els favorits.
 const peaks = ref([])
 const isLoadingPeaks = ref(true)
 const peaksError = ref('')
+const selectedPeakId = ref(null)
+const cardsContainer = ref(null)
+const peakCardRefs = new Map()
+const markerByPeakId = new Map()
 
 function mapPeakToCard(peak) {
   return {
@@ -167,10 +187,19 @@ const displayedPublications = computed(() => {
 
 // Llista d'imatges del carrusel.
 // Ara mateix també són imatges externes temporals per avançar en el frontend.
-const heroImages = [
-  "https://images.unsplash.com/photo-1500530855697-b586d89ba3ee?auto=format&fit=crop&w=1400&q=80",
-  "https://images.unsplash.com/photo-1464822759023-fed622ff2c3b?auto=format&fit=crop&w=1400&q=80",
-  "https://images.unsplash.com/photo-1506744038136-46273834b3fb?auto=format&fit=crop&w=1400&q=80",
+const heroSlides = [
+  {
+    image: "https://images.unsplash.com/photo-1500530855697-b586d89ba3ee?auto=format&fit=crop&w=1400&q=80",
+    text: 'Explora cims i descobreix nous racons de muntanya.',
+  },
+  {
+    image: "https://images.unsplash.com/photo-1464822759023-fed622ff2c3b?auto=format&fit=crop&w=1400&q=80",
+    text: 'Crea la teva ruta i prepara cada sortida amb calma.',
+  },
+  {
+    image: "https://images.unsplash.com/photo-1506744038136-46273834b3fb?auto=format&fit=crop&w=1400&q=80",
+    text: 'Publica la teva sortida i comparteix-la amb la comunitat.',
+  },
 ]
 
 // currentSlide controla quina imatge del hero s'està mostrant.
@@ -200,6 +229,68 @@ function getApiErrorMessage(error) {
   return message
 }
 
+function setPeakCardRef(peakId, el) {
+  if (!el) {
+    peakCardRefs.delete(peakId)
+    return
+  }
+
+  peakCardRefs.set(peakId, el.$el || el)
+}
+
+function scrollToPeakCard(peakId) {
+  const container = cardsContainer.value
+  const card = peakCardRefs.get(peakId)
+
+  if (!container || !card) return
+
+  const containerRect = container.getBoundingClientRect()
+  const cardRect = card.getBoundingClientRect()
+  const currentScroll = container.scrollTop
+  const cardTopInsideContainer = cardRect.top - containerRect.top + currentScroll
+  const centeredTop = cardTopInsideContainer - (container.clientHeight / 2) + (card.clientHeight / 2)
+
+  container.scrollTo({
+    top: Math.max(0, centeredTop),
+    behavior: 'smooth',
+  })
+}
+
+function updateMarkerIcons() {
+  markerByPeakId.forEach((marker, peakId) => {
+    marker.setIcon(peakId === selectedPeakId.value ? selectedPeakIcon : peakIcon)
+  })
+}
+
+function selectPeak(publication, options = {}) {
+  selectedPeakId.value = publication.peakId
+  updateMarkerIcons()
+
+  if (options.scrollCard) {
+    scrollToPeakCard(publication.peakId)
+  }
+
+  const marker = markerByPeakId.get(publication.peakId)
+  if (marker && options.openPopup) {
+    marker.openPopup()
+  }
+
+  const lat = Number(publication.lat)
+  const lng = Number(publication.lng)
+
+  if (map && Number.isFinite(lat) && Number.isFinite(lng) && options.centerMap) {
+    const targetZoom = Math.max(map.getZoom(), 10)
+    map.flyTo([lat, lng], targetZoom, { duration: 0.55 })
+  }
+}
+
+function handleCardSelect(publication) {
+  selectPeak(publication, {
+    centerMap: true,
+    openPopup: true,
+  })
+}
+
 async function renderMarkers() {
   // Aquesta funció pinta al mapa un marcador per cada cim destacat que tingui coordenades.
   if (!map) return
@@ -212,6 +303,7 @@ async function renderMarkers() {
     markerLayer = L.layerGroup().addTo(map)
   }
 
+  markerByPeakId.clear()
   const markers = []
 
   displayedPublications.value.forEach((publication) => {
@@ -224,7 +316,14 @@ async function renderMarkers() {
         ${publication.region}
       `)
 
+    marker.on('click', () => {
+      selectPeak(publication, {
+        scrollCard: true,
+      })
+    })
+
     markerLayer.addLayer(marker)
+    markerByPeakId.set(publication.peakId, marker)
     markers.push(marker)
   })
 
@@ -261,7 +360,7 @@ async function fetchPeaks() {
 onMounted(() => {
   // Quan la vista es carrega, fem que el carrusel canviï d'imatge cada 3.5 segons.
   slideInterval = setInterval(() => {
-    currentSlide.value = (currentSlide.value + 1) % heroImages.length
+    currentSlide.value = (currentSlide.value + 1) % heroSlides.length
   }, 3500)
 
   // Si encara no tenim el contenidor del mapa, parem aquí per evitar errors.
@@ -345,7 +444,7 @@ onBeforeUnmount(() => {
 /* Zona del text principal que hi ha sota la imatge. */
 .hero__text-block {
   text-align: center;
-  padding: 1.2rem 1rem 0.2rem;
+  padding: 1.2rem 1rem 0.35rem;
 }
 
 /* Títol principal "CimsCat". */
@@ -360,10 +459,18 @@ onBeforeUnmount(() => {
   letter-spacing: -0.02em;
 }
 
+.hero__intro {
+  max-width: 620px;
+  margin: 0.7rem auto 0;
+  color: var(--color-text-soft);
+  font-size: 1.08rem;
+  line-height: 1.5;
+}
+
 /* Subtítol que apareix a sobre de la imatge. */
 .hero__subtitle {
   margin: 0;
-  max-width: 52ch;
+  max-width: 58ch;
   color: rgba(255,255,255,0.92);
   line-height: 1.5;
   font-size: 1.5rem;
@@ -471,6 +578,18 @@ onBeforeUnmount(() => {
   background: #f4f2fb;
   color: #625a86;
   border: 1px solid #dcd6f3;
+}
+
+.featured-section__card {
+  cursor: pointer;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease, transform 0.2s ease;
+}
+
+.featured-section__card--selected {
+  border-color: #2d6a4f;
+  background: #f7fbf8;
+  box-shadow: 0 0 0 3px rgba(45, 106, 79, 0.16);
+  transform: translateY(-1px);
 }
 
 /* Personalitzem una mica l'scrollbar per semblar-nos més al wireframe. */

--- a/frontend/src/views/PeakDetailView.vue
+++ b/frontend/src/views/PeakDetailView.vue
@@ -29,6 +29,7 @@
             <h1 class="peak-detail-title">{{ peak.nom }}</h1>
             <p class="peak-detail-elevation">{{ formatMeters(peak.alcada) }}</p>
             <p v-if="peak.comarca" class="peak-detail-comarca">{{ peak.comarca }}</p>
+            <p v-if="peak.descripcio" class="peak-detail-description">{{ peak.descripcio }}</p>
           </header>
 
           <section class="peak-detail-section">
@@ -116,7 +117,6 @@
 import { computed, ref, watch } from 'vue'
 import { useRoute } from 'vue-router'
 import api from '../api/axios'
-import { peakDetailsMock } from '../mocks/peakDetails'
 import { resolveMediaUrl } from '../utils/media'
 
 const route = useRoute()
@@ -124,7 +124,6 @@ const route = useRoute()
 const peak = ref(null)
 const isLoading = ref(true)
 const errorMessage = ref('')
-const isUsingMockData = ref(false)
 
 // Si el cim no té imatge o la ruta és incorrecta, fem servir una foto de suport.
 const fallbackImage =
@@ -134,15 +133,12 @@ const fallbackImage =
 const resolvedPeakImage = computed(() => resolveMediaUrl(peak.value?.imatgeUrl) || fallbackImage)
 
 const locationItems = computed(() => {
-  // Aquesta secció intenta aprofitar primer la forma "rica" del mock.
-  // Si no hi és, reconstruïm la localització amb els camps bàsics del backend.
+  // Reconstruïm la localització només amb els camps reals que retorna el backend.
   if (!peak.value) return []
-  if (peak.value.detailSections?.location) return peak.value.detailSections.location
 
   const items = []
 
   if (peak.value.massis) items.push({ label: 'Massís', value: peak.value.massis })
-  if (peak.value.comarca) items.push({ label: 'Comarca', value: peak.value.comarca })
   if (peak.value.lat && peak.value.lon) {
     items.push({
       label: 'Coordenades',
@@ -155,10 +151,9 @@ const locationItems = computed(() => {
 })
 
 const accessItems = computed(() => {
-  // Igual que a localització, aquí usem detailSections.access si existeix.
-  // Si no, intentem reconstruir la informació a partir de la ruta principal del cim.
+  // Si hi ha una ruta vinculada al cim, la fem servir com a accés principal.
+  // Si no n'hi ha, la secció queda buida.
   if (!peak.value) return []
-  if (peak.value.detailSections?.access) return peak.value.detailSections.access
 
   const primaryRoute = peak.value.routes?.[0]
   if (!primaryRoute) return []
@@ -179,18 +174,23 @@ const accessItems = computed(() => {
 })
 
 const technicalItems = computed(() => {
-  // Aquest bloc agrupa la part més "numèrica" o resum tècnic del cim.
+  // Aquest bloc mostra només característiques pròpies del cim o de la ruta principal.
+  // No hi posem estadístiques internes com guardats, publicacions o rutes vinculades.
   if (!peak.value) return []
-  if (peak.value.detailSections?.technical) return peak.value.detailSections.technical
 
   const primaryRoute = peak.value.routes?.[0]
   const items = [
     { label: 'Alçada', value: formatMeters(peak.value.alcada) },
-    { label: 'Cims guardats', value: String(peak.value.stats.savedCount) },
-    { label: 'Publicacions relacionades', value: String(peak.value.stats.publicacionsCount) },
-    { label: 'Rutes vinculades', value: String(peak.value.stats.rutesCount) },
   ]
 
+  if (peak.value.dificultat) items.push({ label: 'Dificultat', value: peak.value.dificultat })
+  if (primaryRoute?.distanciaKm) items.push({ label: 'Distància', value: formatDistance(primaryRoute.distanciaKm) })
+  if (primaryRoute?.desnivellPosM || primaryRoute?.desnivellPosM === 0) {
+    items.push({ label: 'Desnivell positiu', value: formatMeters(primaryRoute.desnivellPosM) })
+  }
+  if (primaryRoute?.tempsMin || primaryRoute?.tempsMin === 0) {
+    items.push({ label: 'Temps estimat', value: formatTime(primaryRoute.tempsMin) })
+  }
   if (primaryRoute?.altitudMaxM || primaryRoute?.altitudMaxM === 0) {
     items.push({ label: 'Altitud màxima', value: formatMeters(primaryRoute.altitudMaxM) })
   }
@@ -203,15 +203,10 @@ const technicalItems = computed(() => {
 })
 
 const refugeItems = computed(() => {
-  // Aquesta part l'omplim amb els refugis del mock o, si no n'hi ha,
-  // amb punts de la primera ruta vinculada al cim.
+  // El backend actual no té camps específics de refugis o punts d'interès.
+  // Mantenim la secció a la fitxa, però no hi inventem contingut.
   if (!peak.value) return []
-  if (peak.value.detailSections?.refuges) return peak.value.detailSections.refuges
-
-  return peak.value.routes?.[0]?.points?.map((point) => ({
-    label: point.nomPunt || point.etiqueta || 'Punt',
-    value: `${Number(point.lat).toFixed(4)}, ${Number(point.lon).toFixed(4)}`,
-  })) || []
+  return []
 })
 
 function resolvePublicationImage(publication) {
@@ -229,26 +224,16 @@ function getApiErrorMessage(error) {
 }
 
 async function fetchPeakDetail() {
-  // Primer intentem carregar el cim real des de backend.
-  // Si el backend falla i tenim mock per aquell id, el mostrem igualment.
+  // Carreguem sempre la fitxa real del backend.
   isLoading.value = true
   errorMessage.value = ''
-  isUsingMockData.value = false
 
   try {
     const { data } = await api.get(`/peaks/${route.params.id}`)
     peak.value = data.peak
   } catch (error) {
-    const fallbackPeak = peakDetailsMock[String(route.params.id)]
-
-    if (fallbackPeak) {
-      peak.value = fallbackPeak
-      isUsingMockData.value = true
-      errorMessage.value = ''
-    } else {
-      peak.value = null
-      errorMessage.value = getApiErrorMessage(error)
-    }
+    peak.value = null
+    errorMessage.value = getApiErrorMessage(error)
   } finally {
     isLoading.value = false
   }
@@ -287,25 +272,28 @@ watch(
 
 <style scoped>
 .peak-detail-view {
-  padding: 1.5rem;
+  padding: 1.35rem 1.5rem 2rem;
 }
 
 .peak-detail-card {
   background: var(--color-surface);
+  max-width: 1180px;
+  margin: 0 auto;
 }
 
 .peak-detail-eyebrow {
-  margin: 0 0 0.9rem;
-  font-size: 0.95rem;
-  color: #b3b3b0;
+  margin: 0 0 1rem;
+  font-size: 1.05rem;
+  color: #a5a5a0;
 }
 
 .peak-detail-layout {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) 280px;
-  gap: 1.5rem;
-  padding: 1.2rem;
-  border: 1px solid var(--color-border);
+  grid-template-columns: minmax(0, 1fr) minmax(300px, 390px);
+  gap: 2.1rem;
+  align-items: start;
+  padding: 1.6rem 1.8rem;
+  border: 1px solid #c8c8c2;
 }
 
 .peak-detail-notice {
@@ -320,18 +308,20 @@ watch(
 }
 
 .peak-detail-header {
-  margin-bottom: 1rem;
+  margin-bottom: 1.35rem;
 }
 
 .peak-detail-title {
   margin: 0;
-  font-size: 2.1rem;
+  font-size: clamp(2.2rem, 4vw, 3.6rem);
   line-height: 1.05;
   color: var(--color-text);
+  letter-spacing: 0;
 }
 
 .peak-detail-elevation {
   margin: 0.45rem 0 0;
+  font-size: 1.18rem;
   font-weight: 700;
   color: #6f6f6a;
 }
@@ -342,14 +332,23 @@ watch(
   color: #6f6f6a;
 }
 
+.peak-detail-description {
+  max-width: 620px;
+  margin: 0.5rem 0 0;
+  color: #77776f;
+  font-size: 1.02rem;
+  line-height: 1.5;
+}
+
 .peak-detail-section + .peak-detail-section {
-  margin-top: 1.4rem;
+  margin-top: 1.65rem;
 }
 
 .peak-detail-section__title,
 .peak-detail-sidebar__title {
   margin: 0 0 0.55rem;
-  font-size: 1.15rem;
+  font-size: 1.34rem;
+  line-height: 1.2;
   color: #6d6d68;
 }
 
@@ -357,7 +356,9 @@ watch(
   margin: 0;
   padding-left: 1.2rem;
   color: #66665f;
-  line-height: 1.45;
+  font-size: 1rem;
+  line-height: 1.5;
+  min-height: 0.25rem;
 }
 
 .peak-detail-list li + li {
@@ -371,27 +372,30 @@ watch(
 .peak-detail-sidebar {
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: 1.35rem;
 }
 
 .peak-detail-image {
   width: 100%;
-  height: 345px;
+  aspect-ratio: 1 / 1.18;
+  height: auto;
   object-fit: cover;
-  border: 1px solid var(--color-border);
+  border: 1px solid #b9b9b4;
+  background: #f4f4f1;
 }
 
 .publication-list {
   display: grid;
-  gap: 0.7rem;
+  gap: 0.55rem;
 }
 
 .publication-card {
   display: grid;
-  grid-template-columns: 74px minmax(0, 1fr);
-  gap: 0.65rem;
-  border: 1px solid var(--color-border);
-  padding: 0.45rem;
+  grid-template-columns: 88px minmax(0, 1fr);
+  gap: 0.75rem;
+  border: 1px solid #d7d7d2;
+  border-radius: 4px;
+  padding: 0.55rem;
   text-decoration: none;
   color: inherit;
   background: #fff;
@@ -399,13 +403,13 @@ watch(
 
 .publication-card__image {
   width: 100%;
-  height: 74px;
+  height: 82px;
   object-fit: cover;
 }
 
 .publication-card__title {
   margin: 0;
-  font-size: 0.9rem;
+  font-size: 0.92rem;
   line-height: 1.3;
   color: var(--color-text);
 }

--- a/frontend/src/views/PlanRouteView.vue
+++ b/frontend/src/views/PlanRouteView.vue
@@ -1,135 +1,176 @@
 <template>
   <section class="plan-route-view">
     <header class="plan-route-header">
-      <div>
-        <p class="plan-route-eyebrow">Planificador de rutes</p>
-        <h1 class="plan-route-title">Planificar nova ruta</h1>
-      </div>
-
-      <div class="plan-route-header__status">
-        <p v-if="!userStore.isAuthenticated" class="plan-route-auth">
-          Inicia sessio per guardar rutes planificades.
-        </p>
-      </div>
+      <h1 class="plan-route-title">Planificar Ruta</h1>
+      <label class="plan-route-search">
+        <span>Buscar cim, comarca o ruta</span>
+        <input type="search" placeholder="Buscar cim, comarca o ruta..." />
+      </label>
     </header>
 
-    <div class="plan-route-grid">
-      <section class="plan-route-map">
-        <div class="plan-route-map__frame">
-          <div ref="mapContainer" class="plan-route-map__canvas"></div>
-          <div class="plan-route-map__overlay">
-            Fes clic al mapa per afegir punts. Pots editar el nom de cada punt a la dreta.
-          </div>
-        </div>
+    <section class="plan-route-map-card">
+      <div class="plan-route-map__frame">
+        <div ref="mapContainer" class="plan-route-map__canvas"></div>
 
-        <div class="plan-route-stats">
-          <article class="plan-route-stat">
-            <span>Distancia</span>
-            <strong>{{ formattedDistance }}</strong>
-          </article>
-          <article class="plan-route-stat">
-            <span>Temps estimat</span>
-            <strong>{{ formattedTime }}</strong>
-          </article>
-          <article class="plan-route-stat">
-            <span>Desnivell +</span>
-            <strong>{{ positiveElevation }} m</strong>
-          </article>
-          <article class="plan-route-stat">
-            <span>Desnivell -</span>
-            <strong>{{ negativeElevation }} m</strong>
-          </article>
-        </div>
-      </section>
+        <aside class="route-panel">
+          <h2>La teva ruta</h2>
 
-      <aside class="plan-route-panel">
-        <div v-if="isLoadingPeaks" class="plan-route-state">
-          Carregant cataleg de cims...
-        </div>
-
-        <div v-else-if="peaksError && !isUsingMockPeaks" class="plan-route-state plan-route-state--error">
-          {{ peaksError }}
-        </div>
-
-        <div v-else class="plan-route-form">
-
-          <label class="plan-route-field">
-            <span>Nom de la ruta</span>
-            <input v-model="form.nom" type="text" placeholder="Ex. Ruta circular a La Mola" />
-          </label>
-
-          <label class="plan-route-field">
-            <span>Cim principal</span>
-            <select v-model="form.cimId">
-              <option value="">Selecciona un cim</option>
-              <option v-for="peak in peaks" :key="peak.id" :value="peak.id">
-                {{ peak.nom }} · {{ peak.comarca }}
-              </option>
-            </select>
-          </label>
-
-          <div class="plan-route-grid-mini">
-            <label class="plan-route-field">
-              <span>Tipus activitat</span>
-              <input v-model="form.tipusActivitat" type="text" placeholder="senderisme" />
-            </label>
-            <label class="plan-route-field">
-              <span>Ritme</span>
-              <input v-model="form.ritme" type="text" placeholder="moderat" />
-            </label>
+          <div v-if="isLoadingPeaks" class="plan-route-state">
+            Carregant catàleg de cims...
           </div>
 
-          <label class="plan-route-field">
-            <span>Tipus de recorregut</span>
-            <select v-model="form.tipusRecorregut">
-              <option value="one-way">one-way</option>
-              <option value="round-trip">round-trip</option>
-              <option value="circular">circular</option>
-            </select>
-          </label>
+          <div v-else-if="peaksError && !isUsingMockPeaks" class="plan-route-state plan-route-state--error">
+            {{ peaksError }}
+          </div>
 
-          <section class="plan-route-waypoints">
-            <div class="plan-route-waypoints__header">
-              <h2>Punts de ruta</h2>
-              <span>{{ waypoints.length }} punts</span>
+          <div v-else class="plan-route-form">
+            <label class="plan-route-field">
+              <span>Cim principal</span>
+              <select v-model="form.cimId">
+                <option value="">Selecciona un cim</option>
+                <option v-for="peak in peaks" :key="peak.id" :value="peak.id">
+                  {{ peak.nom }} · {{ peak.comarca }}
+                </option>
+              </select>
+            </label>
+
+            <label class="plan-route-field">
+              <span>Nom de la ruta</span>
+              <input v-model="form.nom" type="text" placeholder="Ex. Ruta circular al Pedraforca" />
+            </label>
+
+            <div class="route-panel__row">
+              <span>Esport</span>
+              <select v-model="form.tipusActivitat">
+                <option value="senderisme">Senderisme</option>
+                <option value="trail">Trail running</option>
+                <option value="alpinisme">Alpinisme</option>
+                <option value="btt">BTT</option>
+              </select>
             </div>
 
-            <p v-if="!waypoints.length" class="plan-route-waypoints__empty">
-              Encara no hi ha punts. Fes clic al mapa per afegir-los.
-            </p>
+            <div class="route-panel__row">
+              <span>Ritme</span>
+              <select v-model="form.ritme">
+                <option value="relaxat">Relaxat</option>
+                <option value="moderat">Moderat</option>
+                <option value="rapid">Ràpid</option>
+              </select>
+            </div>
 
-            <article v-for="(point, index) in waypoints" :key="point.id" class="plan-route-waypoint">
-              <div class="plan-route-waypoint__row">
-                <strong>Punt {{ index + 1 }}</strong>
-                <span>{{ formatCoords(point.lat, point.lng) }}</span>
+            <div class="route-panel__row">
+              <span>Tipus</span>
+              <select v-model="form.tipusRecorregut">
+                <option value="one-way">Anada</option>
+                <option value="round-trip">Anada i tornada</option>
+                <option value="circular">Circular</option>
+              </select>
+            </div>
+
+            <section class="plan-route-waypoints">
+              <div class="plan-route-waypoints__header">
+                <h3>Punts de pas</h3>
+                <span>{{ waypoints.length }} punts</span>
               </div>
-              <label>
-                Nom punt
-                <input v-model="point.nomPunt" type="text" placeholder="Punt A" />
-              </label>
-              <label>
-                Etiqueta
-                <input v-model="point.etiqueta" type="text" placeholder="sortida, cim, pas..." />
-              </label>
-              <button class="plan-route-waypoint__remove" type="button" @click="removeWaypoint(point.id)">
-                Treure punt
-              </button>
+
+              <p v-if="!waypoints.length" class="plan-route-waypoints__empty">
+                Fes clic al mapa per afegir punts.
+              </p>
+
+              <article v-for="(point, index) in waypoints" :key="point.id" class="plan-route-waypoint">
+                <div class="plan-route-waypoint__row">
+                  <strong>{{ index === 0 ? 'A' : index + 1 }}</strong>
+                  <span>{{ formatCoords(point.lat, point.lng) }}</span>
+                </div>
+                <input v-model="point.nomPunt" type="text" :placeholder="`Punt de pas ${index + 1}`" />
+                <button class="plan-route-waypoint__remove" type="button" @click="removeWaypoint(point.id)">
+                  Treure
+                </button>
+              </article>
+            </section>
+
+            <div v-if="saveError" class="plan-route-message plan-route-message--error">
+              {{ saveError }}
+            </div>
+            <div v-else-if="saveSuccess" class="plan-route-message">
+              {{ saveSuccess }}
+            </div>
+          </div>
+        </aside>
+
+        <button class="plan-route-save" type="button" :disabled="!canSave" @click="handleSave">
+          {{ isSaving ? 'Guardant...' : saveButtonLabel }}
+        </button>
+      </div>
+    </section>
+
+    <section class="route-technical">
+      <h2>Fitxa tècnica ruta</h2>
+
+      <div class="route-technical__grid">
+        <article class="route-card">
+          <h3>Tipus de camins i superfícies</h3>
+
+          <div class="route-bars">
+            <h4>Tipus de camí</h4>
+            <div class="route-bar">
+              <span style="width: 44%"></span>
+              <span style="width: 31%"></span>
+              <span style="width: 25%"></span>
+            </div>
+            <p><strong>Sender de muntanya:</strong> {{ formattedDistance }}</p>
+            <p><strong>Pista forestal:</strong> pendent de dades reals</p>
+            <p><strong>Sender tècnic:</strong> pendent de dades reals</p>
+          </div>
+
+          <div class="route-bars">
+            <h4>Superfícies</h4>
+            <div class="route-bar route-bar--surface">
+              <span style="width: 52%"></span>
+              <span style="width: 28%"></span>
+              <span style="width: 20%"></span>
+            </div>
+            <p><strong>Camí natural:</strong> estimació visual</p>
+            <p><strong>Grava o pista:</strong> pendent de dades reals</p>
+            <p><strong>Desconegut:</strong> pendent de classificació</p>
+          </div>
+        </article>
+
+        <article class="route-card route-card--details">
+          <h3>Detalls de la ruta</h3>
+
+          <div class="route-summary-grid">
+            <article>
+              <span>Distància</span>
+              <strong>{{ formattedDistance }}</strong>
             </article>
-          </section>
-
-          <div v-if="saveError" class="plan-route-message plan-route-message--error">
-            {{ saveError }}
+            <article>
+              <span>Temps estimat</span>
+              <strong>{{ formattedTime }}</strong>
+            </article>
+            <article>
+              <span>Desnivell +</span>
+              <strong>{{ positiveElevation }} m</strong>
+            </article>
+            <article>
+              <span>Desnivell -</span>
+              <strong>{{ negativeElevation }} m</strong>
+            </article>
           </div>
-          <div v-else-if="saveSuccess" class="plan-route-message">
-            {{ saveSuccess }}
+
+          <div class="route-elevation">
+            <div class="route-elevation__line"></div>
+            <span class="route-elevation__point route-elevation__point--one">A</span>
+            <span class="route-elevation__point route-elevation__point--two">!</span>
+            <span class="route-elevation__point route-elevation__point--three">!</span>
           </div>
 
-          <button class="plan-route-submit" type="button" :disabled="!canSave" @click="handleSave">
-            {{ isSaving ? 'Guardant...' : saveButtonLabel }}
-          </button>
-        </div>
-      </aside>
-    </div>
+          <p class="route-note">
+            La informació tècnica avançada del relleu, les superfícies i els trams exposats queda preparada com a millora futura.
+          </p>
+        </article>
+      </div>
+    </section>
   </section>
 </template>
 
@@ -137,10 +178,12 @@
 import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 import L from 'leaflet'
 import 'leaflet/dist/leaflet.css'
+import { useRoute } from 'vue-router'
 import api from '../api/axios'
 import { useUserStore } from '../stores/user'
 
 const userStore = useUserStore()
+const route = useRoute()
 
 const fallbackPeaks = [
   { id: 'cim_la_mola', nom: 'La Mola', comarca: 'Valles Occidental', alcada: 1104 },
@@ -178,6 +221,7 @@ const isSaving = ref(false)
 const saveError = ref('')
 const saveSuccess = ref('')
 const savedRoute = ref(null)
+const editingRouteId = ref('')
 
 const canSave = computed(() => {
   return (
@@ -188,7 +232,11 @@ const canSave = computed(() => {
   )
 })
 
-const saveButtonLabel = computed(() => (savedRoute.value ? 'Ruta guardada' : 'Guardar ruta'))
+const saveButtonLabel = computed(() => {
+  if (isSaving.value) return editingRouteId.value ? 'Guardant canvis...' : 'Guardant...'
+  if (editingRouteId.value) return 'Guardar canvis'
+  return savedRoute.value ? 'Ruta guardada' : 'Guardar ruta'
+})
 
 function getApiErrorMessage(error, fallbackMessage) {
   return (
@@ -217,6 +265,43 @@ async function fetchPeaks() {
     }
   } finally {
     isLoadingPeaks.value = false
+  }
+}
+
+async function loadRouteForEditing(routeId) {
+  if (!routeId) return
+
+  saveError.value = ''
+  saveSuccess.value = ''
+
+  try {
+    const { data } = await api.get(`/routes/${routeId}`)
+    const routeDetail = data.route
+    if (!routeDetail) return
+
+    editingRouteId.value = routeDetail.id
+    savedRoute.value = routeDetail
+    form.value = {
+      nom: routeDetail.nom || '',
+      cimId: routeDetail.cimId || '',
+      tipusActivitat: routeDetail.tipusActivitat || 'senderisme',
+      ritme: routeDetail.ritme || 'moderat',
+      tipusRecorregut: routeDetail.tipusRecorregut || 'circular',
+    }
+    waypoints.value = [...(routeDetail.waypoints || [])]
+      .sort((a, b) => (a.ordreIndex ?? 0) - (b.ordreIndex ?? 0))
+      .map((point, index) => ({
+        id: point.id || `wp-loaded-${index}`,
+        lat: Number(point.lat),
+        lng: Number(point.lon),
+        nomPunt: point.nomPunt || '',
+        etiqueta: point.etiqueta || '',
+      }))
+      .filter((point) => Number.isFinite(point.lat) && Number.isFinite(point.lng))
+
+    await renderWaypoints()
+  } catch (error) {
+    saveError.value = getApiErrorMessage(error, 'No hem pogut carregar aquesta ruta.')
   }
 }
 
@@ -331,7 +416,7 @@ async function handleSave() {
   saveSuccess.value = ''
 
   if (!userStore.isAuthenticated) {
-    saveError.value = 'Cal iniciar sessio per guardar la ruta.'
+    saveError.value = 'Cal iniciar sessió per guardar la ruta.'
     return
   }
 
@@ -341,7 +426,7 @@ async function handleSave() {
   }
 
   if (!form.value.nom.trim()) {
-    saveError.value = 'El nom de la ruta es obligatori.'
+    saveError.value = 'El nom de la ruta és obligatori.'
     return
   }
 
@@ -377,9 +462,13 @@ async function handleSave() {
       })),
     }
 
-    const { data } = await api.post('/routes', payload)
+    const wasEditing = Boolean(editingRouteId.value)
+    const { data } = wasEditing
+      ? await api.put(`/routes/${editingRouteId.value}`, payload)
+      : await api.post('/routes', payload)
     savedRoute.value = data.route
-    saveSuccess.value = 'Ruta guardada correctament.'
+    if (data.route?.id) editingRouteId.value = data.route.id
+    saveSuccess.value = wasEditing ? 'Ruta actualitzada correctament.' : 'Ruta guardada correctament.'
   } catch (error) {
     saveError.value = getApiErrorMessage(error, 'No hem pogut guardar la ruta.')
   } finally {
@@ -391,8 +480,23 @@ watch(waypoints, () => {
   renderWaypoints()
 }, { deep: true })
 
-onMounted(() => {
-  fetchPeaks()
+watch(
+  () => form.value.cimId,
+  (cimId) => {
+    if (!map || !cimId) return
+
+    const peak = peaks.value.find((item) => item.id === cimId)
+    const lat = Number(peak?.lat)
+    const lon = Number(peak?.lon)
+
+    if (!Number.isFinite(lat) || !Number.isFinite(lon)) return
+
+    map.flyTo([lat, lon], 13, { duration: 0.7 })
+  },
+)
+
+onMounted(async () => {
+  await fetchPeaks()
 
   if (!mapContainer.value) return
 
@@ -406,9 +510,19 @@ onMounted(() => {
     addWaypoint(event.latlng)
   })
 
+  requestAnimationFrame(() => {
+    map?.invalidateSize()
+  })
+
   setTimeout(() => {
     map?.invalidateSize()
-  }, 0)
+  }, 250)
+
+  setTimeout(() => {
+    map?.invalidateSize()
+  }, 750)
+
+  await loadRouteForEditing(String(route.query.routeId || ''))
 })
 
 onBeforeUnmount(() => {
@@ -425,152 +539,100 @@ onBeforeUnmount(() => {
 .plan-route-view {
   max-width: 1200px;
   margin: 0 auto;
-  padding: 2rem 0 3rem;
+  padding: 1.4rem 1rem 3rem;
+  background: #fff;
 }
 
 .plan-route-header {
   display: flex;
   justify-content: space-between;
-  gap: 2rem;
-  align-items: flex-start;
-  margin-bottom: 1.75rem;
-}
-
-.route-planner-hero {
-  border-radius: 22px;
-  padding: 1.4rem;
-  margin-bottom: 1rem;
-}
-
-.route-planner-hero__content {
-  display: flex;
-  justify-content: space-between;
-  align-items: flex-end;
   gap: 1.5rem;
+  align-items: center;
+  margin-bottom: 1.2rem;
 }
 
-.route-planner-eyebrow {
-  margin: 0 0 0.35rem;
-  color: #7f8977;
-  text-transform: uppercase;
-  letter-spacing: 0.12em;
-  font-size: 0.78rem;
-  font-weight: 700;
-}
-
-.route-planner-hero h1,
-.route-sidebar h2,
-.route-elevation-copy h2 {
+.plan-route-title {
   margin: 0;
-  font-size: clamp(2.1rem, 5vw, 3.3rem);
-  line-height: 1.04;
+  font-family: 'Inter', sans-serif;
+  font-size: clamp(2rem, 4vw, 3rem);
+  line-height: 1.05;
   color: var(--color-text);
 }
 
-.plan-route-text {
-  margin: 0.8rem 0 0;
+.plan-route-search {
+  min-width: min(390px, 100%);
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
   color: var(--color-text-soft);
-  max-width: 68ch;
-  line-height: 1.7;
+  font-size: 0.85rem;
 }
 
-.plan-route-warning {
-  margin: 0.8rem 0 0;
-  color: #7b6a45;
-  background: #fff7e1;
-  border: 1px solid #e7d9b2;
-  padding: 0.7rem 0.9rem;
-  border-radius: 12px;
-  max-width: 58ch;
+.plan-route-search input {
+  border: 1px solid var(--color-border);
+  border-radius: 999px;
+  padding: 0.75rem 1rem;
+  background: #f1edf3;
+  color: var(--color-text);
+  min-height: 42px;
 }
 
-.plan-route-header__status {
-  min-width: 220px;
-}
-
-.plan-route-auth {
-  margin: 0;
-  padding: 0.9rem 1rem;
-  border-radius: 12px;
-  background: #fff2f4;
-  border: 1px solid #ead1d8;
-  color: #8b3c4a;
-}
-
-.plan-route-auth--ok {
-  background: #f2f8f1;
-  border-color: #d4e2cd;
-  color: #2d6a4f;
-}
-
-.plan-route-grid {
-  display: grid;
-  grid-template-columns: minmax(0, 2fr) minmax(0, 1fr);
-  gap: 1.6rem;
+.plan-route-map-card {
+  margin-bottom: 1.25rem;
 }
 
 .plan-route-map__frame {
   position: relative;
-  border-radius: 18px;
+  border-radius: 0;
   overflow: hidden;
   border: 1px solid var(--color-border);
   background: #f4f1f8;
-  min-height: 420px;
+  min-height: 470px;
 }
 
 .plan-route-map__canvas {
-  height: 420px;
+  height: 470px;
   width: 100%;
+  min-height: 470px;
+  background: #f4f1f8;
+  z-index: 1;
 }
 
-.plan-route-map__overlay {
+.route-panel {
   position: absolute;
-  bottom: 1rem;
+  top: 1rem;
   left: 1rem;
-  background: rgba(15, 24, 21, 0.75);
-  color: #fff;
-  padding: 0.6rem 0.9rem;
+  z-index: 500;
+  width: min(330px, calc(100% - 2rem));
+  max-height: calc(100% - 2rem);
+  overflow-y: auto;
+  background: rgba(255, 255, 255, 0.96);
   border-radius: 12px;
-  font-size: 0.9rem;
+  border: 1px solid rgba(0, 0, 0, 0.12);
+  box-shadow: 0 12px 30px rgba(0, 0, 0, 0.18);
+  padding: 0.85rem;
 }
 
-.plan-route-stats {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 0.75rem;
-  margin-top: 1rem;
-}
-
-.plan-route-stat {
-  background: #f3f5ea;
-  border: 1px solid #d8dfc6;
-  border-radius: 12px;
-  padding: 0.8rem 0.9rem;
-  display: flex;
-  flex-direction: column;
-  gap: 0.25rem;
-}
-
-.plan-route-stat span {
-  color: var(--color-text-soft);
-  font-size: 0.9rem;
-}
-
-.plan-route-stat strong {
-  font-size: 1.1rem;
+.route-panel h2 {
+  margin: 0 0 0.75rem;
+  font-size: 1rem;
   color: var(--color-text);
 }
 
-.plan-route-panel {
-  background: var(--color-surface);
-  border: 1px solid var(--color-border);
-  border-radius: 18px;
-  padding: 1.5rem;
+.route-panel__row {
+  display: grid;
+  grid-template-columns: 85px 1fr;
+  align-items: center;
+  gap: 0.7rem;
+  border-top: 1px solid #eee9e3;
+  padding: 0.65rem 0;
+  font-size: 0.9rem;
+  color: var(--color-text);
 }
 
 .plan-route-state {
-  padding: 1rem;
-  border-radius: 12px;
+  padding: 0.8rem;
+  border-radius: 8px;
   background: #f6f6f1;
   color: var(--color-text-soft);
 }
@@ -584,40 +646,35 @@ onBeforeUnmount(() => {
 .plan-route-form {
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: 0.75rem;
 }
 
 .plan-route-field {
   display: flex;
   flex-direction: column;
-  gap: 0.4rem;
+  gap: 0.35rem;
   font-weight: 600;
   color: var(--color-text);
+  font-size: 0.9rem;
 }
 
 .plan-route-field input,
-.plan-route-field select {
+.plan-route-field select,
+.route-panel__row select {
   border: 1px solid var(--color-border);
-  border-radius: 12px;
-  padding: 0.8rem 0.9rem;
+  border-radius: 8px;
+  padding: 0.6rem 0.7rem;
   background: #fff;
   color: var(--color-text);
-}
-
-.plan-route-grid-mini {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 0.75rem;
+  min-width: 0;
 }
 
 .plan-route-waypoints {
-  border: 1px solid #e0dbe8;
-  border-radius: 14px;
-  padding: 0.9rem;
-  background: #faf8fd;
+  border-top: 1px solid #eee9e3;
+  padding-top: 0.7rem;
   display: flex;
   flex-direction: column;
-  gap: 0.9rem;
+  gap: 0.55rem;
 }
 
 .plan-route-waypoints__header {
@@ -626,46 +683,38 @@ onBeforeUnmount(() => {
   align-items: baseline;
 }
 
-.plan-route-waypoints__header h2 {
+.plan-route-waypoints__header h3 {
   margin: 0;
-  font-size: 1.1rem;
+  font-size: 0.95rem;
 }
 
 .plan-route-waypoints__empty {
   margin: 0;
   color: var(--color-text-soft);
+  font-size: 0.88rem;
 }
 
 .plan-route-waypoint {
   border: 1px solid var(--color-border);
-  border-radius: 12px;
-  padding: 0.8rem;
+  border-radius: 10px;
+  padding: 0.55rem;
   background: #fff;
-  display: flex;
-  flex-direction: column;
-  gap: 0.6rem;
+  display: grid;
+  gap: 0.45rem;
 }
 
 .plan-route-waypoint__row {
   display: flex;
   justify-content: space-between;
   gap: 1rem;
-  font-size: 0.92rem;
+  font-size: 0.82rem;
   color: var(--color-text-soft);
-}
-
-.plan-route-waypoint label {
-  display: flex;
-  flex-direction: column;
-  gap: 0.35rem;
-  font-size: 0.9rem;
-  color: var(--color-text);
 }
 
 .plan-route-waypoint input {
   border: 1px solid var(--color-border);
-  border-radius: 10px;
-  padding: 0.6rem 0.75rem;
+  border-radius: 999px;
+  padding: 0.55rem 0.75rem;
 }
 
 .plan-route-waypoint__remove {
@@ -679,11 +728,12 @@ onBeforeUnmount(() => {
 }
 
 .plan-route-message {
-  padding: 0.8rem 0.9rem;
-  border-radius: 12px;
+  padding: 0.7rem 0.8rem;
+  border-radius: 8px;
   background: #f2f8f1;
   color: #2d6a4f;
   border: 1px solid #d4e2cd;
+  font-size: 0.9rem;
 }
 
 .plan-route-message--error {
@@ -692,18 +742,196 @@ onBeforeUnmount(() => {
   border-color: #e3c8c8;
 }
 
-.plan-route-submit {
+.plan-route-save {
+  position: absolute;
+  top: 1rem;
+  right: 1rem;
+  z-index: 500;
   border: none;
-  border-radius: 12px;
-  padding: 0.95rem 1rem;
+  border-radius: 8px;
+  padding: 0.7rem 1rem;
   background: var(--color-button-primary);
   color: var(--color-button-primary-text);
   cursor: pointer;
+  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.18);
 }
 
-.plan-route-submit:disabled {
+.plan-route-save:disabled {
   opacity: 0.6;
   cursor: not-allowed;
+}
+
+.route-technical {
+  margin-top: 1rem;
+}
+
+.route-technical h2 {
+  margin: 0 0 0.9rem;
+  font-size: clamp(1.8rem, 3vw, 2.4rem);
+  color: var(--color-text);
+}
+
+.route-technical__grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+  gap: 1.25rem;
+}
+
+.route-card {
+  background: #f4f1ec;
+  padding: 1rem;
+  border: 1px solid #e5dfd4;
+}
+
+.route-card h3 {
+  margin: 0 0 1rem;
+  font-size: 1.35rem;
+  color: var(--color-text);
+}
+
+.route-bars {
+  background: #fff;
+  border-radius: 10px;
+  padding: 1rem;
+  margin-bottom: 1rem;
+}
+
+.route-bars h4 {
+  margin: 0 0 0.75rem;
+  font-size: 0.95rem;
+}
+
+.route-bars p {
+  margin: 0.45rem 0 0;
+  color: var(--color-text-soft);
+  font-size: 0.9rem;
+}
+
+.route-bar {
+  display: flex;
+  height: 18px;
+  overflow: hidden;
+  border-radius: 4px;
+  background: #e6e0d5;
+  margin-bottom: 0.7rem;
+}
+
+.route-bar span:nth-child(1) {
+  background: #aeb998;
+}
+
+.route-bar span:nth-child(2) {
+  background: #c8c0ad;
+}
+
+.route-bar span:nth-child(3) {
+  background: #9d8564;
+}
+
+.route-bar--surface span:nth-child(1) {
+  background: #bcc9a6;
+}
+
+.route-bar--surface span:nth-child(2) {
+  background: #d2c8b9;
+}
+
+.route-bar--surface span:nth-child(3) {
+  background: #856a48;
+}
+
+.route-summary-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.75rem;
+  margin-bottom: 1rem;
+}
+
+.route-summary-grid article {
+  background: #fff;
+  border-radius: 10px;
+  padding: 0.8rem;
+}
+
+.route-summary-grid span {
+  display: block;
+  color: var(--color-text-soft);
+  font-size: 0.85rem;
+}
+
+.route-summary-grid strong {
+  display: block;
+  margin-top: 0.25rem;
+  color: var(--color-text);
+  font-size: 1.1rem;
+}
+
+.route-elevation {
+  position: relative;
+  height: 170px;
+  background: #fff;
+  border-radius: 10px;
+  overflow: hidden;
+  margin-bottom: 1rem;
+}
+
+.route-elevation::before {
+  content: "";
+  position: absolute;
+  inset: 20px;
+  background:
+    linear-gradient(to right, rgba(0, 0, 0, 0.08) 1px, transparent 1px),
+    linear-gradient(to bottom, rgba(0, 0, 0, 0.08) 1px, transparent 1px);
+  background-size: 70px 44px;
+}
+
+.route-elevation__line {
+  position: absolute;
+  left: 8%;
+  right: 8%;
+  bottom: 42%;
+  height: 65px;
+  border-top: 4px solid #7c1d1d;
+  border-radius: 55% 45% 0 0;
+  transform: skewY(-7deg);
+}
+
+.route-elevation__point {
+  position: absolute;
+  width: 20px;
+  height: 20px;
+  border-radius: 5px;
+  background: #f2a400;
+  color: #fff;
+  font-size: 0.75rem;
+  display: grid;
+  place-items: center;
+  font-weight: 700;
+}
+
+.route-elevation__point--one {
+  left: 16%;
+  top: 45%;
+  background: #6c8f47;
+}
+
+.route-elevation__point--two {
+  left: 48%;
+  top: 34%;
+}
+
+.route-elevation__point--three {
+  right: 18%;
+  top: 29%;
+}
+
+.route-note {
+  margin: 0;
+  padding: 1rem;
+  border-radius: 10px;
+  background: #eee7d8;
+  color: #5f574a;
+  line-height: 1.5;
 }
 
 .plan-route-marker__dot {
@@ -721,12 +949,23 @@ onBeforeUnmount(() => {
 }
 
 @media (max-width: 980px) {
-  .plan-route-grid {
+  .plan-route-header {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .route-technical__grid {
     grid-template-columns: 1fr;
   }
 
-  .plan-route-header {
-    flex-direction: column;
+  .route-panel {
+    position: relative;
+    top: auto;
+    left: auto;
+    width: auto;
+    max-height: none;
+    margin: 0;
+    border-radius: 0;
   }
 }
 
@@ -735,12 +974,12 @@ onBeforeUnmount(() => {
     padding: 1rem 0.5rem 2rem;
   }
 
-  .plan-route-grid-mini {
+  .route-summary-grid {
     grid-template-columns: 1fr;
   }
 
-  .plan-route-stats {
-    grid-template-columns: 1fr;
+  .plan-route-map__canvas {
+    height: 360px;
   }
 }
 </style>

--- a/frontend/src/views/ProfileView.vue
+++ b/frontend/src/views/ProfileView.vue
@@ -60,7 +60,6 @@
       -->
       <HorizontalCarousel
         title="Publicacions guardades"
-        description="Aquesta secció mostra les publicacions a les quals has donat like."
         :items="likedPublications"
         empty-text="Encara no has donat like a cap publicació."
       >
@@ -82,7 +81,6 @@
 
       <HorizontalCarousel
         title="Rutes planificades"
-        :description="plannedRoutesDescription"
         :items="plannedRoutes"
         empty-text="Encara no tens cap ruta planificada guardada."
       >
@@ -91,7 +89,7 @@
             <h3 class="profile-route-card__title">{{ item.nom || 'Ruta sense nom' }}</h3>
             <p class="profile-route-card__meta">
               {{ item.tipusActivitat || 'senderisme' }} · {{ item.ritme || 'moderat' }} ·
-              {{ item.tipusRecorregut || 'anada' }}
+              {{ formatRouteType(item.tipusRecorregut) }}
             </p>
             <p class="profile-route-card__stats">
               {{ formatDistance(item.distanciaKm) }} · {{ formatTime(item.tempsMin) }} ·
@@ -101,6 +99,9 @@
               {{ item.peak?.nom || 'Cim no disponible' }} · {{ item.peak?.comarca || 'Comarca' }}
             </p>
             <p class="profile-route-card__date">Guardada {{ formatDate(item.createdAt) }}</p>
+            <RouterLink :to="`/planificar?routeId=${item.id}`" class="profile-route-card__link">
+              Veure ruta
+            </RouterLink>
           </article>
         </template>
       </HorizontalCarousel>
@@ -210,12 +211,6 @@ const editForm = computed(() => ({
   nomUsuari: profile.value?.nomUsuari || '',
   fotoPerfil: profile.value?.fotoPerfil || '',
 }))
-const plannedRoutesDescription = computed(() =>
-  plannedRoutes.value.length
-    ? 'Aquestes són les rutes que has guardat des del planificador.'
-    : '',
-)
-
 function getApiErrorMessage(error, fallbackMessage) {
   // Intentem recuperar el missatge més concret que ens hagi tornat el backend.
   // Si no hi ha cap text útil, fem servir el missatge genèric que ens arriba per paràmetre.
@@ -318,6 +313,16 @@ function formatDate(value) {
     month: 'long',
     year: 'numeric',
   })
+}
+
+function formatRouteType(value) {
+  const labels = {
+    'one-way': 'anada',
+    'round-trip': 'anada i tornada',
+    circular: 'circular',
+  }
+
+  return labels[value] || value || 'anada'
 }
 
 async function handleProfileUpdate(payload) {
@@ -505,11 +510,13 @@ watch(
 }
 
 .profile-route-card {
-  min-height: 210px;
+  width: 260px;
+  min-width: 260px;
+  min-height: 260px;
   padding: 1rem;
   border: 1px solid var(--color-border);
   border-radius: 14px;
-  background: #faf8f2;
+  background: var(--color-surface);
   display: flex;
   flex-direction: column;
   gap: 0.55rem;
@@ -531,8 +538,18 @@ watch(
 }
 
 .profile-route-card__date {
-  margin-top: auto;
   font-size: 0.92rem;
+}
+
+.profile-route-card__link {
+  width: fit-content;
+  text-decoration: none;
+  color: var(--color-text);
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  padding: 0.45rem 0.8rem;
+  background: #fff;
+  margin-top: 0.25rem;
 }
 
 @media (max-width: 900px) {

--- a/frontend/src/views/PublicationView.vue
+++ b/frontend/src/views/PublicationView.vue
@@ -143,7 +143,7 @@
           <div>
             <h2 class="publication-section-title">Mapa de la ruta</h2>
             <p class="publication-map__text">
-              Si la publicacio te una ruta planificada, la veureu dibuixada aqui mateix.
+              Si la publicació té una ruta planificada, la veureu dibuixada aquí mateix.
             </p>
           </div>
 
@@ -160,10 +160,10 @@
 
         <div v-if="hasRouteMap" ref="routeMapContainer" class="publication-map__canvas"></div>
         <p v-else-if="publication.route" class="publication-map__empty">
-          La ruta vinculada no te prou punts per mostrar el mapa.
+          La ruta vinculada no té prou punts per mostrar el mapa.
         </p>
         <p v-else class="publication-map__empty">
-          Aquesta publicacio no te cap ruta planificada vinculada.
+          Aquesta publicació no té cap ruta planificada vinculada.
         </p>
       </section>
 


### PR DESCRIPTION
## Canvis principals

- Millora de la navegació i eliminació d'elements duplicats al navbar.
- Connexió visual entre el mapa i les cards de cims destacats a la Home.
- Ajustos a la fitxa de cim per apropar-la al disseny previst.
- Reordenació i neteja del formulari de creació de publicacions.
- Redisseny de la vista de planificació de rutes.
- Possibilitat d'obrir i modificar una ruta planificada des del perfil.
- Ajustos visuals a les cards de rutes planificades.
- Correcció de textos i accents en diverses pantalles.
- Documentació del bloc de polit a `docs/CIMSCAT_PULIR_DETALLS.md`.

## Validació

- `npm run build` executat correctament al frontend.

## Notes

No s'ha modificat backend, Prisma, migracions ni seeds.